### PR TITLE
tweak travis pytests

### DIFF
--- a/biothings_explorer/test/test_hint.py
+++ b/biothings_explorer/test/test_hint.py
@@ -1,9 +1,0 @@
-from pytest import fixture
-
-@fixture
-def ht():
-    from biothings_explorer.hint import Hint
-    return Hint()
-
-def test_ht_gene(ht):
-    assert ht.query("CXCR4")['Gene'][0]['symbol'] == 'CXCR4'

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ pytest
 
 # biothings_schema
 -e git+https://github.com/biothings/biothings_schema.py#egg=biothings_schema.py
-
+-e git+https://github.com/biothings/biothings_explorer#egg=biothings_explorer


### PR DESCRIPTION
I was attempting to get the travis pytests to a passing state.  Wasn't quite successful, but looks like these minor tweaks get closer.  Now actually failing on the content of the tests, not on configuration...

Currently on master, lots of `ImportError: No module named 'biothings_explorer'` errors (https://travis-ci.org/biothings/biothings_explorer/builds/650147945).  Now, at least it gets to `9 failed, 29 passed, 7650 warnings in 321.75 seconds` (https://travis-ci.org/biothings/biothings_explorer/builds/650276898)

(up to you @kevinxin90 if this is helpful enough to merge or not...)