### PR TITLE
Improve Current Logging

### DIFF
--- a/src/controllers/QueryGraphHandler/qedge2bteedge.js
+++ b/src/controllers/QueryGraphHandler/qedge2bteedge.js
@@ -37,7 +37,7 @@ module.exports = class QEdge2BTEEdgeHandler {
             return item;
         });
         if (smartapi_edges.length === 0) {
-            this.logs.push(new LogEntry("DEBUG", null, `BTE didn't find any smartapi edges corresponding to ${qEdge.getID()}`).getLog())
+            this.logs.push(new LogEntry("WARNING", null, `BTE didn't find any smartapi edges corresponding to ${qEdge.getID()}`).getLog())
         } else {
             this.logs.push(new LogEntry("DEBUG", null, `BTE found ${smartapi_edges.length} smartapi edges corresponding to ${qEdge.getID()}. These smartaip edges comes from ${new Set(this._findAPIsFromSmartAPIEdges(smartapi_edges)).size} unique APIs. They are ${Array.from(new Set(this._findAPIsFromSmartAPIEdges(smartapi_edges))).join(',')}`).getLog())
         }

--- a/src/controllers/QueryGraphHandler/qedge2bteedge.js
+++ b/src/controllers/QueryGraphHandler/qedge2bteedge.js
@@ -36,7 +36,11 @@ module.exports = class QEdge2BTEEdgeHandler {
             item.reasoner_edge = qEdge;
             return item;
         });
-        this.logs.push(new LogEntry("DEBUG", null, `BTE found ${smartapi_edges.length} smartapi edges corresponding to ${qEdge.getID()}. These smartaip edges comes from ${new Set(this._findAPIsFromSmartAPIEdges(smartapi_edges)).size} unique APIs. They are ${this._findAPIsFromSmartAPIEdges(smartapi_edges)}`).getLog())
+        if (smartapi_edges.length === 0) {
+            this.logs.push(new LogEntry("DEBUG", null, `BTE didn't find any smartapi edges corresponding to ${qEdge.getID()}`).getLog())
+        } else {
+            this.logs.push(new LogEntry("DEBUG", null, `BTE found ${smartapi_edges.length} smartapi edges corresponding to ${qEdge.getID()}. These smartaip edges comes from ${new Set(this._findAPIsFromSmartAPIEdges(smartapi_edges)).size} unique APIs. They are ${Array.from(new Set(this._findAPIsFromSmartAPIEdges(smartapi_edges))).join(',')}`).getLog())
+        }
         return smartapi_edges;
     }
 


### PR DESCRIPTION
If no SmartAPI edge is found for a TRAPI query, should label it as WARNING in TRAPI logs.

Prettify the logging message when there're multiple APIs found.