### PR TITLE
test: :white_check_mark: fix test for reverse predicate

### DIFF
--- a/__test__/integration/QueryEdge.test.js
+++ b/__test__/integration/QueryEdge.test.js
@@ -127,7 +127,7 @@ describe("Testing QueryEdge Module", () => {
         test("test get reverse predicate if query is reversed", () => {
             const edge = new QEdge("e01", { subject: type_node, object: disease1_node, predicate: "biolink:treats" });
             const res = edge.getPredicate();
-            expect(res).toBe("treated by");
+            expect(res).toBe("treated_by");
         });
 
 


### PR DESCRIPTION
previously missing underscore between treated by

https://github.com/biothings/BioThings_Explorer_TRAPI/issues/29