### PR TITLE
Fix minor bugs

### DIFF
--- a/__test__/integration/reverse.test.js
+++ b/__test__/integration/reverse.test.js
@@ -6,4 +6,10 @@ describe("Test EdgeReverse class", () => {
         const res = handler.reverse('treats');
         expect(res).toBe("treated_by");
     })
+
+    test("test reverse with correct predicate", () => {
+        const handler = new Reverse();
+        const res = handler.reverse('treated_by');
+        expect(res).toBe("treats");
+    })
 })

--- a/src/controllers/QueryGraphHandler/knowledge_graph.js
+++ b/src/controllers/QueryGraphHandler/knowledge_graph.js
@@ -80,7 +80,7 @@ module.exports = class KnowledgeGraph {
     _createEdge(record) {
         return {
             [helper._createUniqueEdgeID(record)]: {
-                predicate: "biolink:" + record["$association"].predicate,
+                predicate: "biolink:" + record["$reasoner_edge"].getQueryPredicate(),
                 subject: helper._getInputID(record),
                 object: helper._getOutputID(record),
                 attributes: this._createAttributes(record)

--- a/src/controllers/QueryGraphHandler/query_edge.js
+++ b/src/controllers/QueryGraphHandler/query_edge.js
@@ -30,6 +30,13 @@ module.exports = class QEdge {
         return new helper()._generateHash(toBeHashed);
     }
 
+    getQueryPredicate() {
+        if (this.predicate && this.predicate.startsWith("biolink:")) {
+            return this.predicate.slice(8);
+        }
+        return this.predicate
+    }
+
     getPredicate() {
         let predicate = this.predicate;
         if (this.predicate && this.predicate.startsWith("biolink:")) {

--- a/src/controllers/QueryGraphHandler/reverse.js
+++ b/src/controllers/QueryGraphHandler/reverse.js
@@ -8,9 +8,10 @@ module.exports = class EdgeReverse {
     }
 
     reverse(predicate) {
-        if (predicate in this.data.slots) {
-            if ('inverse' in this.data.slots[predicate]) {
-                return this.data.slots[predicate].inverse.replace(' ', '_');
+        let modifiedPredicate = predicate.replace('_', ' ');
+        if (modifiedPredicate in this.data.slots) {
+            if ('inverse' in this.data.slots[modifiedPredicate]) {
+                return this.data.slots[modifiedPredicate].inverse.replace(' ', '_');
             }
         }
         return undefined;


### PR DESCRIPTION
1. The predicate used in the response knowledge graph should be the same as the one used in query graph. (previously is reversed)
2. Should convert the predicate in user graph to predicate in biolink yaml.

close: #29 