### PR TITLE
Add EBI Proteins to APIs BTE uses

### DIFF
--- a/src/routes/v1/config.js
+++ b/src/routes/v1/config.js
@@ -29,7 +29,7 @@ exports.API_LIST = [
     'Multiomics Wellness KP API',
     'BioLink API',
     'LINCS Data Portal API',
-    'EBI Proteins API'
+    'EBI Proteins API',
     'Automat IntAct',
     'Automat Cord19 Scibite',
     'Automat Gtopdb',

--- a/src/routes/v1/config.js
+++ b/src/routes/v1/config.js
@@ -29,6 +29,7 @@ exports.API_LIST = [
     'Multiomics Wellness KP API',
     'BioLink API',
     'LINCS Data Portal API',
+    'EBI Proteins API'
     'Automat IntAct',
     'Automat Cord19 Scibite',
     'Automat Gtopdb',


### PR DESCRIPTION
Add smartapi registration title for EBI Proteins API to this list (see entry here http://smart-api.info/registry?q=43af91b3d7cae43591083bff9d75c6dd)

Done because BTE currently is not calling on this api. 