### PR TITLE
fix: avoid using /predicates when newer endpoint available

### DIFF
--- a/src/controllers/cron/update_local_smartapi.js
+++ b/src/controllers/cron/update_local_smartapi.js
@@ -17,7 +17,7 @@ const getTRAPIWithPredicatesEndpoint = (specs) => {
                 "/query" in spec.paths &&
                 "x-trapi" in spec.info &&
                 spec.servers.length &&
-                "/predicates" in spec.paths || 
+                "/predicates" in spec.paths ||
                 "/meta_knowledge_graph" in spec.paths ||
                 "/1.1/meta_knowledge_graph" in spec.paths
             ) {
@@ -50,7 +50,7 @@ const getTRAPIWithPredicatesEndpoint = (specs) => {
                     api['predicates_path'] = "/meta_knowledge_graph";
                     trapi.push(api);
                 }
-                if (
+                else if (
                     "/1.1/meta_knowledge_graph" in spec.paths &&
                     Object.prototype.hasOwnProperty.call(spec.info["x-trapi"], "version") &&
                     spec.info["x-trapi"].version.includes("1.1")
@@ -59,11 +59,11 @@ const getTRAPIWithPredicatesEndpoint = (specs) => {
                     api['predicates_path'] = "/1.1/meta_knowledge_graph";
                     trapi.push(api);
                     special_cases.push({name: spec.info['title'], id: spec['_id']})
-                }else if("/predicates" in spec.paths ){
+                } else if ("/predicates" in spec.paths ){
                     //1.0
                     api['predicates_path'] = "/predicates";
                     trapi.push(api);
-                }else{
+                } else {
                     debug(
                         `[error]: Unable to parse spec, ${spec ? spec.info.title : spec
                         }. Endpoint required not found.`


### PR DESCRIPTION
Addresses #231.

In cases where a hit in `smartapi_specs.json` exposes both `/meta_knowledge_graph` and `/predicates` paths, `updateSmartAPISpecs` will now default to the former.