### PR TITLE
Support loading config-defined API overrides from URL/local

### DIFF
--- a/src/config/smartapi_overrides.json
+++ b/src/config/smartapi_overrides.json
@@ -1,0 +1,6 @@
+{
+  "conf": {
+    "only_overrides": false
+  },
+  "apis": {}
+}

--- a/src/controllers/cron/update_local_smartapi.js
+++ b/src/controllers/cron/update_local_smartapi.js
@@ -243,20 +243,22 @@ module.exports = () => {
         }
     });
 
-    const overridesPath = path.resolve(__dirname, "../../config/smartapi_overrides.json");
-    let overrides
-    try {
-        overrides = JSON.parse(fs.readFileSync(overridesPath));
-    } catch (error) {
-        debug(`ERROR getting API Overrides file because ${error}`);
-        return;
-    }
-    if (Object.keys(overrides.apis).length > 0) {
-        debug(`API Override(s) set. Updating local SmartAPI specs with overrides now at ${new Date().toUTCString()}!`);
+    if (process.env.API_OVERRIDE === 'true') {
+        const overridesPath = path.resolve(__dirname, "../../config/smartapi_overrides.json");
+        let overrides
         try {
-            updateSmartAPISpecs();
+            overrides = JSON.parse(fs.readFileSync(overridesPath));
         } catch (error) {
-            debug(`Updating local copy of SmartAPI specs failed! The error message is ${err.toString()}`)
+            debug(`ERROR getting API Overrides file because ${error}`);
+            return;
+        }
+        if (Object.keys(overrides.apis).length > 0) {
+            debug(`API Override(s) set. Updating local SmartAPI specs with overrides now at ${new Date().toUTCString()}!`);
+            try {
+                updateSmartAPISpecs();
+            } catch (error) {
+                debug(`Updating local copy of SmartAPI specs failed! The error message is ${err.toString()}`)
+            }
         }
     }
 }


### PR DESCRIPTION
*(Addresses #233)*

This PR allows the user to configure API IDs to be overridden with files from either a URL or the local filesystem. Files are expected to be in YAML format, with local files being expected in the data folder.

`only_overrides` provides the ability to remove all other API hits, and only load those specified in the config.

If the environment variable `API_OVERRIDE=true` is set (e.g. `API_OVERRIDE=true npm run debug --workspace=@biothings-explorer/bte-trapi`), the config is checked at server start and overrides are applied, as well as during subsequent `smartapi_specs.json` updates.

Additionally, if an API is specified with an ID which is not present in the SmartAPI specs, it is appended as a new API hit (and a warning is logged, pending #257).

### Example configs:

Replace the latest MyGene.info API with...the latest MyGene.info API:

```JSON
{
  "conf": {
    "only_overrides": false
  },
  "apis": {
    "59dce17363dce279d389100834e43648": "https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/master/mygene.info/openapi_full.yml"
  }
}
```

Remove all other APIs and load *only* local copies of the MyGene.info and MyChem.info APIs from `bte-trapi/data`:

```JSON
{
  "conf": {
    "only_overrides": true
  },
  "apis": {
    "59dce17363dce279d389100834e43648": "file:///mygene_test.yaml",
    "8f08d1446e0bb9c2b323713ce83e2bd3": "file:///mychem_test.yaml"
  }
}
```
