### PR TITLE
Quick Fix: warn when unknown API ID overridden

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ You may configure a set of API IDs to override from local files or URLs.
 
 If the environment variable `API_OVERRIDE=true` is set (e.g. `API_OVERRIDE=true npm run debug --workspace=@biothings-explorer/bte-trapi`), then `/config/smartapi_overrides.json` is checked at server start and overrides are applied, as well as during subsequent `smartapi_specs.json` updates.
 
-Override files are expected to be in yaml format, with local files expected in the `data` folder. If overrides are specified with IDs not in the current SmartAPI spec, they will be appended as new API hits with a log warning.
+Override files may be specified as a URL which returns the expected yaml file, a `file:///` URL which will search with the `data` folder as the root directory, or an arbitrary filepath. Regardless, override files are expected to be in yaml format. If overrides are specified with IDs not in the current SmartAPI spec, they will be appended as new API hits with a log warning.
 
 You may also set `only_overrides` to `true` in the config to remove all other APIs and keep only the specified overrides.
 

--- a/README.md
+++ b/README.md
@@ -103,12 +103,42 @@ Public Docker image located at [link](https://hub.docker.com/repository/docker/b
 
 ### Usage
 
-You now can POST queries to `http://<HOST>:3000/v1/query`.  
+You now can POST queries to `http://<HOST>:3000/v1/query`.
 
 Query Examples can be found [here](/examples).
 
 
-### Test with local SmartAPI spec
+### Testing with Alternate SmartAPI Specs (local or hosted)
+
+#### Using `API_OVERRIDE=true`
+
+You may configure a set of API IDs to override from local files or URLs.
+
+If the environment variable `API_OVERRIDE=true` is set (e.g. `API_OVERRIDE=true npm run debug --workspace=@biothings-explorer/bte-trapi`), then `/config/smartapi_overrides.json` is checked at server start and overrides are applied, as well as during subsequent `smartapi_specs.json` updates.
+
+Override files are expected to be in yaml format, with local files expected in the `data` folder. If overrides are specified with IDs not in the current SmartAPI spec, they will be appended as new API hits with a log warning.
+
+You may also set `only_overrides` to `true` in the config to remove all other APIs and keep only the specified overrides.
+
+Example:
+
+Replace the latest MyGene.info API with a specific revision, and the MyChem.info API with a local test version:
+
+```JSON
+{
+  "conf": {
+    "only_overrides": false
+  },
+  "apis": {
+    "59dce17363dce279d389100834e43648": "https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/8b36f46d59c82d19b5cba40421a6ca9c2ed62e6b/mygene.info/openapi_full.yml",
+    "8f08d1446e0bb9c2b323713ce83e2bd3": "file:///mychem_test.yaml"
+  }
+}
+```
+
+#### Using `/test/query`
+
+*This method is deprecated, and may be subject to removal in the future.*
 
 The TRAPI interface has `/test/query` endpoint which uses a SmartAPI spec stored at **test** folder named **smartapi.json**
 
@@ -130,4 +160,3 @@ Now, you should be able to test your local smartapi using POST queries at:
 ### Testing on a specific SmartAPI API
 
 By default, BTE queries all APIs specified in the the[ config.js file](https://github.com/biothings/BioThings_Explorer_TRAPI/blob/main/src/routes/v1/config.js).  In some cases, you may want to override that default to specifically query a single API.  For example, the SmartAPI record for the "EBI Proteins API) is [43af91b3d7cae43591083bff9d75c6dd](https://smart-api.info/registry?q=43af91b3d7cae43591083bff9d75c6dd). To instruct BTE to query that API only, you can POST your query to http://localhost:3000/v1/smartapi/43af91b3d7cae43591083bff9d75c6dd/query
-

--- a/__test__/integration/TRAPIv1.1.test.js
+++ b/__test__/integration/TRAPIv1.1.test.js
@@ -201,8 +201,8 @@ describe("Testing v1.1 endpoints", () => {
                 expect(response.body.message.knowledge_graph).toHaveProperty("nodes");
                 expect(response.body.message.knowledge_graph).toHaveProperty("edges");
                 expect(response.body.message.knowledge_graph.nodes).toHaveProperty("MONDO:0016575");
-                expect(response.body.message.knowledge_graph.nodes).toHaveProperty("UMLS:C0008780");
-                expect(response.body.message.knowledge_graph.nodes["UMLS:C0008780"]).toHaveProperty("categories", ["biolink:PhenotypicFeature"]);
+                expect(response.body.message.knowledge_graph.nodes).toHaveProperty("HP:0012265");
+                expect(response.body.message.knowledge_graph.nodes["HP:0012265"]).toHaveProperty("categories", ["biolink:PhenotypicFeature"]);
             })
     })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,10 @@
 {
-  "name": "@biothings-explorer/single-hop-app",
+  "name": "@biothings-explorer/bte-trapi",
   "version": "2.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@biothings-explorer/single-hop-app",
       "version": "2.8.1",
       "license": "ISC",
       "dependencies": {
@@ -20,14 +19,18 @@
         "express": "^4.17.1",
         "express-rate-limit": "^5.2.6",
         "express-winston": "^4.1.0",
+        "file-url": "^4.0.0",
         "helmet": "^4.4.1",
         "husky": "^4.3.8",
+        "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
         "node-cron": "^2.0.3",
         "npm": "^6.14.12",
         "openapi-validator-middleware": "^3.2.2",
         "redis": "^3.1.1",
         "snake-case": "^3.0.4",
+        "valid-url": "^1.0.9",
+        "warning": "^4.0.3",
         "winston": "^3.3.3",
         "winston-daily-rotate-file": "^4.5.1"
       },
@@ -48,6 +51,26 @@
         "@jsdevtools/ono": "^7.1.3",
         "call-me-maybe": "^1.0.1",
         "js-yaml": "^3.13.1"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@apidevtools/openapi-schemas": {
@@ -440,50 +463,18 @@
       "dev": true
     },
     "node_modules/@biothings-explorer/api-response-transform": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@biothings-explorer/api-response-transform/-/api-response-transform-1.11.0.tgz",
-      "integrity": "sha512-AKYBjJgNF27dwOIAPtPU9BP0aMdsqN7bIr9+Q34F24zr3ihAN/H6SYp52NDaqcJXVBctengLmxPMUUUngWFi1g==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@biothings-explorer/api-response-transform/-/api-response-transform-1.12.0.tgz",
+      "integrity": "sha512-UsEnk5Y1pd5sdyCv96CCaGq51u4oBA9SIkP4jYl/RWxDy6tOPE4G9zLFlIhllZjGrvSoOxrfH+6Zc1IsUsGEVQ==",
       "dependencies": {
-        "@biothings-explorer/json-transformer": "^1.0.2",
         "@commitlint/cli": "^11.0.0",
         "@commitlint/config-conventional": "^11.0.0",
-        "axios": "^0.19.2",
+        "axios": "^0.21.1",
+        "common-path-prefix": "^3.0.0",
         "husky": "^4.3.8",
+        "jsonata": "^1.8.4",
         "lodash": "^4.17.21"
       }
-    },
-    "node_modules/@biothings-explorer/api-response-transform/node_modules/axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-      "deprecated": "Critical security vulnerability fixed in v0.21.1. For more information, see https://github.com/axios/axios/pull/3410",
-      "dependencies": {
-        "follow-redirects": "1.5.10"
-      }
-    },
-    "node_modules/@biothings-explorer/api-response-transform/node_modules/debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/@biothings-explorer/api-response-transform/node_modules/follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "dependencies": {
-        "debug": "=3.1.0"
-      },
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/@biothings-explorer/api-response-transform/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node_modules/@biothings-explorer/call-apis": {
       "version": "1.23.2",
@@ -495,16 +486,6 @@
         "biomedical_id_resolver": "^3.9.0",
         "debug": "^4.3.1",
         "husky": "^4.3.8"
-      }
-    },
-    "node_modules/@biothings-explorer/json-transformer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@biothings-explorer/json-transformer/-/json-transformer-1.0.2.tgz",
-      "integrity": "sha512-TvLjFICclkbwK/jbed43PWRf6GrVdE2Y1oP8y9gygzSySWEoBJTxJFABAfgbF2HxqBe3+ZesFnnFCYFCyjrARg==",
-      "dependencies": {
-        "common-path-prefix": "^3.0.0",
-        "jsonata": "^1.8.3",
-        "lodash": "^4.17.19"
       }
     },
     "node_modules/@biothings-explorer/query_graph_handler": {
@@ -528,22 +509,20 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/@biothings-explorer/smartapi-kg": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/@biothings-explorer/smartapi-kg/-/smartapi-kg-3.8.1.tgz",
-      "integrity": "sha512-UuHixjsKV7YnQifNCqV0ozFLsWBkO3BnCiH4gJnuM0rh6vrsiIp1ymrJmp2ZNNId/DnfKsKq98Ks3VsgwOXhsg==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@biothings-explorer/smartapi-kg/-/smartapi-kg-3.9.0.tgz",
+      "integrity": "sha512-PXjx2AAql6wf65ZM5E0OwsVfN1tjWsCtNxoSGo4dmchK+HBE1/kWhCAXxRICSAjTHkcGfoXviJFiZv30lWcpjQ==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@commitlint/cli": "^11.0.0",
         "@commitlint/config-conventional": "^11.0.0",
-        "@types/jest": "^26.0.20",
-        "@types/load-json-file": "^5.1.0",
+        "@types/jest": "^26.0.22",
         "@types/lodash": "^4.14.168",
         "axios": "^0.21.1",
         "camelcase": "^6.2.0",
         "core-js": "^3.9.1",
         "debug": "^4.3.1",
         "husky": "^4.3.8",
-        "jsnetworkx": "^0.3.4",
         "lodash": "^4.17.21"
       }
     },
@@ -1019,6 +998,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -1026,6 +1014,19 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@istanbuljs/schema": {
@@ -1672,15 +1673,6 @@
         "pretty-format": "^26.0.0"
       }
     },
-    "node_modules/@types/load-json-file": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@types/load-json-file/-/load-json-file-5.1.0.tgz",
-      "integrity": "sha512-swfGRs+Irsi+iWl16DjfL7fffh9BEwgvH4eptLmrM05iuoI4bTPmNHTepWb2xf84M43/Xd0fs3jze2T3Xzow/g==",
-      "deprecated": "This is a stub types definition. load-json-file provides its own type definitions, so you do not need this installed.",
-      "dependencies": {
-        "load-json-file": "*"
-      }
-    },
     "node_modules/@types/lodash": {
       "version": "4.14.170",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.170.tgz",
@@ -1949,13 +1941,30 @@
         "uri-js": "^4.2.2"
       }
     },
-    "node_modules/argparse": {
+    "node_modules/api-schema-builder/node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "node_modules/api-schema-builder/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/arr-diff": {
       "version": "4.0.0",
@@ -2134,6 +2143,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/artillery/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
       }
     },
     "node_modules/artillery/node_modules/async": {
@@ -2433,6 +2451,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/artillery/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/artillery/node_modules/latest-version": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
@@ -2719,15 +2750,6 @@
         "signal-exit": "^3.0.2"
       }
     },
-    "node_modules/artillery/node_modules/ws": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
-      "dev": true,
-      "dependencies": {
-        "async-limiter": "~1.0.0"
-      }
-    },
     "node_modules/artillery/node_modules/xdg-basedir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
@@ -2979,14 +3001,6 @@
         "node": ">= 10.14.2"
       }
     },
-    "node_modules/babel-runtime": {
-      "version": "5.8.38",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
-      "integrity": "sha1-HAsC62MxL18If/IEUIJ7QlydTBk=",
-      "dependencies": {
-        "core-js": "^1.0.0"
-      }
-    },
     "node_modules/backo2": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
@@ -3105,68 +3119,30 @@
         "pascal-case": "^3.1.2"
       }
     },
-    "node_modules/biolink-model/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-    },
-    "node_modules/biolink-model/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/biomedical_id_resolver": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/biomedical_id_resolver/-/biomedical_id_resolver-3.9.0.tgz",
-      "integrity": "sha512-bV8sR9tZi7h9QBmzIdwfkEseG/CCsOuDdlgfKVMQ9ApPSjdHl10ZPcRnm9qFe8e+22jrK/lLw7zAK/gkE6gYnQ==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/biomedical_id_resolver/-/biomedical_id_resolver-3.10.0.tgz",
+      "integrity": "sha512-lDoH445DiIRkeu0KTureZNgF0EyAIRsqkzaBYuu8XgPalareTHqxwUCRcrjk5gRtel9TYuaNgK2UA/xQQ4sXlw==",
       "dependencies": {
         "@commitlint/cli": "^11.0.0",
         "@commitlint/config-conventional": "^11.0.0",
-        "axios": "^0.19.2",
-        "biolink-model": "^0.3.1",
+        "axios": "^0.21.1",
+        "biolink-model": "^0.4.0",
         "debug": "^4.3.1",
         "husky": "^4.3.8",
         "lodash": "^4.17.21"
       }
     },
-    "node_modules/biomedical_id_resolver/node_modules/axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-      "deprecated": "Critical security vulnerability fixed in v0.21.1. For more information, see https://github.com/axios/axios/pull/3410",
+    "node_modules/biomedical_id_resolver/node_modules/biolink-model": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/biolink-model/-/biolink-model-0.4.0.tgz",
+      "integrity": "sha512-nu0lJsF1jQYM/82/gOnxXypJ1lO5Ip0WTpXiDQUKxYRqpALpHmExlmXWA4B7Je53BnP9cgZMGlNaP3ZZX1F33w==",
       "dependencies": {
-        "follow-redirects": "1.5.10"
+        "axios": "^0.21.1",
+        "debug": "^4.3.1",
+        "js-yaml": "^4.0.0",
+        "pascal-case": "^3.1.2"
       }
-    },
-    "node_modules/biomedical_id_resolver/node_modules/follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "dependencies": {
-        "debug": "=3.1.0"
-      },
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/biomedical_id_resolver/node_modules/follow-redirects/node_modules/debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/biomedical_id_resolver/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node_modules/blob": {
       "version": "0.0.5",
@@ -3527,34 +3503,40 @@
       }
     },
     "node_modules/cheerio": {
-      "version": "1.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.5.tgz",
-      "integrity": "sha512-yoqps/VCaZgN4pfXtenwHROTp8NG6/Hlt4Jpz2FEP0ZJQ+ZUkVDd0hAPDNKhj3nakpfPt/CNs57yEtxD1bXQiw==",
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.10.tgz",
+      "integrity": "sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==",
       "dev": true,
       "dependencies": {
-        "cheerio-select-tmp": "^0.1.0",
-        "dom-serializer": "~1.2.0",
-        "domhandler": "^4.0.0",
-        "entities": "~2.1.0",
-        "htmlparser2": "^6.0.0",
-        "parse5": "^6.0.0",
-        "parse5-htmlparser2-tree-adapter": "^6.0.0"
+        "cheerio-select": "^1.5.0",
+        "dom-serializer": "^1.3.2",
+        "domhandler": "^4.2.0",
+        "htmlparser2": "^6.1.0",
+        "parse5": "^6.0.1",
+        "parse5-htmlparser2-tree-adapter": "^6.0.1",
+        "tslib": "^2.2.0"
       },
       "engines": {
-        "node": ">= 0.12"
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
       }
     },
-    "node_modules/cheerio-select-tmp": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/cheerio-select-tmp/-/cheerio-select-tmp-0.1.1.tgz",
-      "integrity": "sha512-YYs5JvbpU19VYJyj+F7oYrIE2BOll1/hRU7rEy/5+v9BzkSo3bK81iAeeQEMI92vRIxz677m72UmJUiVwwgjfQ==",
+    "node_modules/cheerio-select": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.5.0.tgz",
+      "integrity": "sha512-qocaHPv5ypefh6YNxvnbABM07KMxExbtbfuJoIie3iZXX1ERwYmJcIiRrr9H05ucQP1k28dav8rpdDgjQd8drg==",
       "dev": true,
       "dependencies": {
-        "css-select": "^3.1.2",
-        "css-what": "^4.0.0",
-        "domelementtype": "^2.1.0",
-        "domhandler": "^4.0.0",
-        "domutils": "^2.4.4"
+        "css-select": "^4.1.3",
+        "css-what": "^5.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0",
+        "domutils": "^2.7.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/cheerio/node_modules/parse5": {
@@ -4264,9 +4246,9 @@
       }
     },
     "node_modules/conventional-changelog-core/node_modules/read-pkg/node_modules/hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "node_modules/conventional-changelog-core/node_modules/read-pkg/node_modules/normalize-package-data": {
@@ -4521,11 +4503,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-    },
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -4577,6 +4554,28 @@
         "node": ">=6"
       }
     },
+    "node_modules/coveralls/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/coveralls/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/create-error-class": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
@@ -4623,25 +4622,31 @@
       }
     },
     "node_modules/css-select": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-3.1.2.tgz",
-      "integrity": "sha512-qmss1EihSuBNWNNhHjxzxSfJoFBM/lERB/Q4EnsJQQC62R2evJDW481091oAdOr9uh46/0n4nrg0It5cAnj1RA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
+      "integrity": "sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==",
       "dev": true,
       "dependencies": {
         "boolbase": "^1.0.0",
-        "css-what": "^4.0.0",
-        "domhandler": "^4.0.0",
-        "domutils": "^2.4.3",
+        "css-what": "^5.0.0",
+        "domhandler": "^4.2.0",
+        "domutils": "^2.6.0",
         "nth-check": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/css-what": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-4.0.0.tgz",
-      "integrity": "sha512-teijzG7kwYfNVsUh2H/YN62xW3KK9YhXEgSlbxMlcyjPNvdKJqFx5lrwlJgoFP1ZHlB89iGDlo/JyshKeRhv5A==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
+      "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
       "dev": true,
       "engines": {
         "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/cssom": {
@@ -4972,21 +4977,30 @@
       }
     },
     "node_modules/dom-serializer": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.2.0.tgz",
-      "integrity": "sha512-n6kZFH/KlCrqs/1GHMOd5i2fd/beQHuehKdWvNNffbGHTr/almdhuVvTVFb3V7fglz+nC50fFusu3lY33h12pA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+      "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
       "dev": true,
       "dependencies": {
         "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
+        "domhandler": "^4.2.0",
         "entities": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
       }
     },
     "node_modules/domelementtype": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
-      "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==",
-      "dev": true
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
     },
     "node_modules/domexception": {
       "version": "2.0.1",
@@ -5010,26 +5024,32 @@
       }
     },
     "node_modules/domhandler": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
-      "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
+      "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
       "dev": true,
       "dependencies": {
-        "domelementtype": "^2.1.0"
+        "domelementtype": "^2.2.0"
       },
       "engines": {
         "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
     "node_modules/domutils": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.4.tgz",
-      "integrity": "sha512-jBC0vOsECI4OMdD0GC9mGn7NXPLb+Qt6KW1YDQzeQYRUFKmNG8lh7mO5HiELfr+lLQE7loDVI4QcAxV80HS+RA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
+      "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
       "dev": true,
       "dependencies": {
         "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0"
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dot-case": {
@@ -5186,9 +5206,9 @@
       }
     },
     "node_modules/engine.io-client": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.1.tgz",
-      "integrity": "sha512-oVu9kBkGbcggulyVF0kz6BV3ganqUeqXvD79WOFKa+11oK692w1NyFkuEj4xrkFRpZhn92QOqTk4RQq5LiBXbQ==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.2.tgz",
+      "integrity": "sha512-QEqIp+gJ/kMHeUun7f5Vv3bteRHppHH/FMBQX/esFj/fuYfjyUKWGMo3VCvIP/V8bE9KcjHmRZrhIz2Z9oNsDA==",
       "dev": true,
       "dependencies": {
         "component-emitter": "~1.3.0",
@@ -5200,7 +5220,7 @@
         "parseqs": "0.0.6",
         "parseuri": "0.0.6",
         "ws": "~7.4.2",
-        "xmlhttprequest-ssl": "~1.5.4",
+        "xmlhttprequest-ssl": "~1.6.2",
         "yeast": "0.1.2"
       }
     },
@@ -5220,12 +5240,24 @@
       "dev": true
     },
     "node_modules/engine.io-client/node_modules/ws": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
-      "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==",
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
       "dev": true,
       "engines": {
         "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/engine.io-parser": {
@@ -5242,10 +5274,13 @@
       }
     },
     "node_modules/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
-      "dev": true
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -5732,6 +5767,17 @@
       "integrity": "sha512-VYb3HZ/GiAGUCrfeakO8Mp54YGswNUHvL7P09WQcXAJNSj3iQ5QraYSp3cIn1MUyw6uzfgN/EFOarCNa4JvUHQ==",
       "dependencies": {
         "moment": "^2.11.2"
+      }
+    },
+    "node_modules/file-url": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/file-url/-/file-url-4.0.0.tgz",
+      "integrity": "sha512-vRCdScQ6j3Ku6Kd7W1kZk9c++5SqD6Xz5Jotrjr/nkY714M14RFHy/AAVA2WQvpsqVAVgTbDrYyBpU205F0cLw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/fill-range": {
@@ -6332,9 +6378,9 @@
       }
     },
     "node_modules/glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -6627,9 +6673,9 @@
       }
     },
     "node_modules/hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
     },
     "node_modules/html-encoding-sniffer": {
       "version": "2.0.1",
@@ -6650,14 +6696,21 @@
       "dev": true
     },
     "node_modules/htmlparser2": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.0.0.tgz",
-      "integrity": "sha512-numTQtDZMoh78zJpaNdJ9MXb2cv5G3jwUoe3dMQODubZvLoGvTE/Ofp6sHvH8OGKcN/8A47pGLi/k58xHP/Tfw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
       "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
       "dependencies": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.0.0",
-        "domutils": "^2.4.4",
+        "domutils": "^2.5.2",
         "entities": "^2.0.0"
       }
     },
@@ -7320,7 +7373,8 @@
     "node_modules/is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
     },
     "node_modules/is-valid-path": {
       "version": "0.1.1",
@@ -8984,12 +9038,11 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -9059,12 +9112,24 @@
       }
     },
     "node_modules/jsdom/node_modules/ws": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
-      "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
+      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
       "dev": true,
       "engines": {
         "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -9078,22 +9143,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/jsnetworkx": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/jsnetworkx/-/jsnetworkx-0.3.4.tgz",
-      "integrity": "sha1-HAAl35QgjOtcxZ5lj5qb9f709vQ=",
-      "dependencies": {
-        "babel-runtime": "^5",
-        "lodash": "^3.3.1",
-        "through": "^2.3.6",
-        "tiny-sprintf": "^0.3.0"
-      }
-    },
-    "node_modules/jsnetworkx/node_modules/lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
     },
     "node_modules/json-buffer": {
       "version": "3.0.0",
@@ -9163,9 +9212,9 @@
       }
     },
     "node_modules/jsonata": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/jsonata/-/jsonata-1.8.4.tgz",
-      "integrity": "sha512-OqzmM5IICtm/687zckG5BROZzInGCEuKojpYs48H8RnkII8Np+o912ryvhnYwsRrSI24TQRG/qqrSwBuaneDbg==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/jsonata/-/jsonata-1.8.5.tgz",
+      "integrity": "sha512-ilDyTBkg6qhNoNVr8PUPzz5GYvRK+REKOM5MdOGzH2y6V4yvPRMegSvbZLpbTtI0QAgz09QM7drDhSHUlwp9pA==",
       "engines": {
         "node": ">= 8"
       }
@@ -9188,14 +9237,14 @@
       ]
     },
     "node_modules/jsonpath": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.1.0.tgz",
-      "integrity": "sha512-CZHwa1sZOf42qkIyK7evwToFXeTB4iplbl6Z9CVwU0wmBQPffL6gtYJXCoeciJoZENMuzaidPjhp2iOLRei4wQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.1.1.tgz",
+      "integrity": "sha512-l6Cg7jRpixfbgoWgkrl77dgEj8RPvND0wMH6TwQmi9Qs4TFfS9u5cUFnbeKTwj5ga5Y3BTGGNI28k117LJ009w==",
       "dev": true,
       "dependencies": {
         "esprima": "1.2.2",
         "static-eval": "2.0.2",
-        "underscore": "1.7.0"
+        "underscore": "1.12.1"
       }
     },
     "node_modules/jsonpath/node_modules/esprima": {
@@ -9324,6 +9373,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "parse-json": "^2.2.0",
@@ -9339,6 +9389,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
       "dependencies": {
         "error-ex": "^1.2.0"
       },
@@ -9350,6 +9401,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "dev": true,
       "dependencies": {
         "is-utf8": "^0.2.0"
       },
@@ -9459,6 +9511,17 @@
         "fecha": "^4.2.0",
         "ms": "^2.1.1",
         "triple-beam": "^1.3.0"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/loud-rejection": {
@@ -9605,9 +9668,9 @@
       }
     },
     "node_modules/meow/node_modules/hosted-git-info": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.7.tgz",
-      "integrity": "sha512-fWqc0IcuXs+BmE9orLDyVykAG9GJtGLGuZAAqgcckPgv5xad4AcXGIv8galtQvlwutxSlaMcdw7BUtq2EIvqCQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.8.tgz",
+      "integrity": "sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -10087,191 +10150,66 @@
       }
     },
     "node_modules/normalize-url": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
       "dev": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/npm": {
-      "version": "6.14.12",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.12.tgz",
-      "integrity": "sha512-La0TNNm1TLYaSeOyit+p3xGTRYYRsHae6/RG69MVXurZsWna9jccPP7FOi/u7V9WdiCV5OOojrfMD+WstO5MZQ==",
+      "version": "6.14.14",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.14.tgz",
+      "integrity": "sha512-4TnYPV3rvwk9m92ON0iFrdXtRyMhrNkGdI8sr3dy1HVE3pVNxR9FyWYbjAw/HjfmHvmHUbxTVbmjAMv8NhIa6Q==",
       "bundleDependencies": [
-        "JSONStream",
         "abbrev",
-        "agent-base",
-        "agentkeepalive",
-        "ansi-align",
-        "ansi-regex",
-        "ansi-styles",
         "ansicolors",
         "ansistyles",
         "aproba",
         "archy",
-        "are-we-there-yet",
-        "asap",
-        "asn1",
-        "assert-plus",
-        "asynckit",
-        "aws-sign2",
-        "aws4",
-        "balanced-match",
-        "bcrypt-pbkdf",
         "bin-links",
         "bluebird",
-        "boxen",
-        "brace-expansion",
-        "buffer-from",
-        "builtins",
-        "byline",
         "byte-size",
         "cacache",
         "call-limit",
-        "camelcase",
-        "capture-stack-trace",
-        "caseless",
-        "chalk",
         "chownr",
         "ci-info",
-        "cidr-regex",
-        "cli-boxes",
         "cli-columns",
         "cli-table3",
-        "cliui",
-        "clone",
         "cmd-shim",
-        "code-point-at",
-        "color-convert",
-        "color-name",
-        "colors",
         "columnify",
-        "combined-stream",
-        "concat-map",
-        "concat-stream",
         "config-chain",
-        "configstore",
-        "console-control-strings",
-        "copy-concurrently",
-        "core-util-is",
-        "create-error-class",
-        "cross-spawn",
-        "crypto-random-string",
-        "cyclist",
-        "dashdash",
-        "debug",
         "debuglog",
-        "decamelize",
-        "decode-uri-component",
-        "deep-extend",
-        "defaults",
-        "define-properties",
-        "delayed-stream",
-        "delegates",
         "detect-indent",
         "detect-newline",
         "dezalgo",
-        "dot-prop",
-        "dotenv",
-        "duplexer3",
-        "duplexify",
-        "ecc-jsbn",
         "editor",
-        "emoji-regex",
-        "encoding",
-        "end-of-stream",
-        "env-paths",
-        "err-code",
-        "errno",
-        "es-abstract",
-        "es-to-primitive",
-        "es6-promise",
-        "es6-promisify",
-        "escape-string-regexp",
-        "execa",
-        "extend",
-        "extsprintf",
-        "fast-json-stable-stringify",
         "figgy-pudding",
         "find-npm-prefix",
-        "flush-write-stream",
-        "forever-agent",
-        "form-data",
-        "from2",
-        "fs-minipass",
         "fs-vacuum",
         "fs-write-stream-atomic",
-        "fs.realpath",
-        "function-bind",
-        "gauge",
-        "genfun",
         "gentle-fs",
-        "get-caller-file",
-        "get-stream",
-        "getpass",
         "glob",
-        "global-dirs",
-        "got",
         "graceful-fs",
-        "har-schema",
-        "har-validator",
-        "has",
-        "has-flag",
-        "has-symbols",
         "has-unicode",
         "hosted-git-info",
-        "http-cache-semantics",
-        "http-proxy-agent",
-        "http-signature",
-        "https-proxy-agent",
-        "humanize-ms",
-        "iconv-lite",
         "iferr",
-        "ignore-walk",
-        "import-lazy",
         "imurmurhash",
         "infer-owner",
         "inflight",
         "inherits",
         "ini",
         "init-package-json",
-        "ip",
-        "ip-regex",
-        "is-callable",
-        "is-ci",
         "is-cidr",
-        "is-date-object",
-        "is-fullwidth-code-point",
-        "is-installed-globally",
-        "is-npm",
-        "is-obj",
-        "is-path-inside",
-        "is-redirect",
-        "is-regex",
-        "is-retry-allowed",
-        "is-stream",
-        "is-symbol",
-        "is-typedarray",
-        "isarray",
-        "isexe",
-        "isstream",
-        "jsbn",
         "json-parse-better-errors",
-        "json-schema",
-        "json-stringify-safe",
-        "jsonparse",
-        "jsprim",
-        "latest-version",
+        "JSONStream",
         "lazy-property",
         "libcipm",
         "libnpm",
         "libnpmaccess",
-        "libnpmconfig",
         "libnpmhook",
         "libnpmorg",
-        "libnpmpublish",
         "libnpmsearch",
         "libnpmteam",
         "libnpx",
@@ -10282,179 +10220,72 @@
         "lodash._bindcallback",
         "lodash._cacheindexof",
         "lodash._createcache",
-        "lodash._createset",
         "lodash._getnative",
-        "lodash._root",
         "lodash.clonedeep",
         "lodash.restparam",
         "lodash.union",
         "lodash.uniq",
         "lodash.without",
-        "lowercase-keys",
         "lru-cache",
-        "make-dir",
-        "make-fetch-happen",
         "meant",
-        "mime-db",
-        "mime-types",
-        "minimatch",
-        "minimist",
-        "minizlib",
         "mississippi",
         "mkdirp",
         "move-concurrently",
-        "ms",
-        "mute-stream",
-        "node-fetch-npm",
         "node-gyp",
         "nopt",
         "normalize-package-data",
         "npm-audit-report",
-        "npm-bundled",
         "npm-cache-filename",
         "npm-install-checks",
         "npm-lifecycle",
-        "npm-logical-tree",
-        "npm-normalize-package-bin",
         "npm-package-arg",
         "npm-packlist",
         "npm-pick-manifest",
         "npm-profile",
         "npm-registry-fetch",
-        "npm-run-path",
         "npm-user-validate",
         "npmlog",
-        "number-is-nan",
-        "oauth-sign",
-        "object-assign",
-        "object-keys",
-        "object.getownpropertydescriptors",
         "once",
         "opener",
-        "os-homedir",
-        "os-tmpdir",
         "osenv",
-        "p-finally",
-        "package-json",
         "pacote",
-        "parallel-transform",
-        "path-exists",
-        "path-is-absolute",
         "path-is-inside",
-        "path-key",
-        "path-parse",
-        "performance-now",
-        "pify",
-        "prepend-http",
-        "process-nextick-args",
         "promise-inflight",
-        "promise-retry",
-        "promzard",
-        "proto-list",
-        "protoduck",
-        "prr",
-        "pseudomap",
-        "psl",
-        "pump",
-        "pumpify",
-        "punycode",
         "qrcode-terminal",
-        "qs",
         "query-string",
         "qw",
-        "rc",
-        "read",
         "read-cmd-shim",
         "read-installed",
         "read-package-json",
         "read-package-tree",
+        "read",
         "readable-stream",
         "readdir-scoped-modules",
-        "registry-auth-token",
-        "registry-url",
         "request",
-        "require-directory",
-        "require-main-filename",
-        "resolve-from",
         "retry",
         "rimraf",
-        "run-queue",
         "safe-buffer",
-        "safer-buffer",
         "semver",
-        "semver-diff",
-        "set-blocking",
         "sha",
-        "shebang-command",
-        "shebang-regex",
-        "signal-exit",
         "slide",
-        "smart-buffer",
-        "socks",
-        "socks-proxy-agent",
         "sorted-object",
         "sorted-union-stream",
-        "spdx-correct",
-        "spdx-exceptions",
-        "spdx-expression-parse",
-        "spdx-license-ids",
-        "split-on-first",
-        "sshpk",
         "ssri",
-        "stream-each",
-        "stream-iterate",
-        "stream-shift",
-        "strict-uri-encode",
-        "string-width",
-        "string_decoder",
         "stringify-package",
-        "strip-ansi",
-        "strip-eof",
-        "strip-json-comments",
-        "supports-color",
         "tar",
-        "term-size",
         "text-table",
-        "through",
-        "through2",
-        "timed-out",
         "tiny-relative-date",
-        "tough-cookie",
-        "tunnel-agent",
-        "tweetnacl",
-        "typedarray",
         "uid-number",
         "umask",
         "unique-filename",
-        "unique-slug",
-        "unique-string",
         "unpipe",
-        "unzip-response",
         "update-notifier",
-        "uri-js",
-        "url-parse-lax",
-        "util-deprecate",
-        "util-extend",
-        "util-promisify",
         "uuid",
         "validate-npm-package-license",
         "validate-npm-package-name",
-        "verror",
-        "wcwidth",
         "which",
-        "which-module",
-        "wide-align",
-        "widest-line",
         "worker-farm",
-        "wrap-ansi",
-        "wrappy",
-        "write-file-atomic",
-        "xdg-basedir",
-        "xtend",
-        "y18n",
-        "yallist",
-        "yargs",
-        "yargs-parser"
+        "write-file-atomic"
       ],
       "dependencies": {
         "abbrev": "~1.1.1",
@@ -10487,7 +10318,7 @@
         "glob": "^7.1.6",
         "graceful-fs": "^4.2.4",
         "has-unicode": "~2.0.1",
-        "hosted-git-info": "^2.8.8",
+        "hosted-git-info": "^2.8.9",
         "iferr": "^1.0.2",
         "imurmurhash": "*",
         "infer-owner": "^1.0.4",
@@ -10564,9 +10395,9 @@
         "slide": "~1.1.6",
         "sorted-object": "~2.0.1",
         "sorted-union-stream": "~2.1.3",
-        "ssri": "^6.0.1",
+        "ssri": "^6.0.2",
         "stringify-package": "^1.0.1",
-        "tar": "^4.4.13",
+        "tar": "^4.4.15",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
         "uid-number": "0.0.6",
@@ -11934,7 +11765,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
-      "version": "2.8.8",
+      "version": "2.8.9",
       "inBundle": true,
       "license": "ISC"
     },
@@ -13793,7 +13624,7 @@
       }
     },
     "node_modules/npm/node_modules/ssri": {
-      "version": "6.0.1",
+      "version": "6.0.2",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13949,7 +13780,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "4.4.13",
+      "version": "4.4.15",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14528,6 +14359,9 @@
       "dev": true,
       "dependencies": {
         "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/null-check": {
@@ -15005,9 +14839,9 @@
       }
     },
     "node_modules/path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
@@ -15050,6 +14884,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15058,6 +14893,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15066,6 +14902,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
       "dependencies": {
         "pinkie": "^2.0.0"
       },
@@ -17191,11 +17028,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/tiny-sprintf": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/tiny-sprintf/-/tiny-sprintf-0.3.0.tgz",
-      "integrity": "sha1-QnL9XB0vkoByI/wW1yj98wWVoz4="
-    },
     "node_modules/tmp": {
       "version": "0.0.28",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
@@ -17340,9 +17172,9 @@
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
     },
     "node_modules/trim-newlines": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
-      "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
       "engines": {
         "node": ">=8"
       }
@@ -17488,9 +17320,9 @@
       "dev": true
     },
     "node_modules/underscore": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==",
       "dev": true
     },
     "node_modules/union-value": {
@@ -17829,6 +17661,14 @@
         "makeerror": "1.0.x"
       }
     },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
@@ -18049,6 +17889,15 @@
         "typedarray-to-buffer": "^3.1.5"
       }
     },
+    "node_modules/ws": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.3.tgz",
+      "integrity": "sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==",
+      "dev": true,
+      "dependencies": {
+        "async-limiter": "~1.0.0"
+      }
+    },
     "node_modules/xdg-basedir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
@@ -18071,9 +17920,9 @@
       "dev": true
     },
     "node_modules/xmlhttprequest-ssl": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
-      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz",
+      "integrity": "sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
@@ -18182,6 +18031,25 @@
         "@jsdevtools/ono": "^7.1.3",
         "call-me-maybe": "^1.0.1",
         "js-yaml": "^3.13.1"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        }
       }
     },
     "@apidevtools/openapi-schemas": {
@@ -18560,47 +18428,17 @@
       "dev": true
     },
     "@biothings-explorer/api-response-transform": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@biothings-explorer/api-response-transform/-/api-response-transform-1.11.0.tgz",
-      "integrity": "sha512-AKYBjJgNF27dwOIAPtPU9BP0aMdsqN7bIr9+Q34F24zr3ihAN/H6SYp52NDaqcJXVBctengLmxPMUUUngWFi1g==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@biothings-explorer/api-response-transform/-/api-response-transform-1.12.0.tgz",
+      "integrity": "sha512-UsEnk5Y1pd5sdyCv96CCaGq51u4oBA9SIkP4jYl/RWxDy6tOPE4G9zLFlIhllZjGrvSoOxrfH+6Zc1IsUsGEVQ==",
       "requires": {
-        "@biothings-explorer/json-transformer": "^1.0.2",
         "@commitlint/cli": "^11.0.0",
         "@commitlint/config-conventional": "^11.0.0",
-        "axios": "^0.19.2",
+        "axios": "^0.21.1",
+        "common-path-prefix": "^3.0.0",
         "husky": "^4.3.8",
+        "jsonata": "^1.8.4",
         "lodash": "^4.17.21"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.19.2",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-          "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-          "requires": {
-            "follow-redirects": "1.5.10"
-          }
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "follow-redirects": {
-          "version": "1.5.10",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-          "requires": {
-            "debug": "=3.1.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
       }
     },
     "@biothings-explorer/call-apis": {
@@ -18613,16 +18451,6 @@
         "biomedical_id_resolver": "^3.9.0",
         "debug": "^4.3.1",
         "husky": "^4.3.8"
-      }
-    },
-    "@biothings-explorer/json-transformer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@biothings-explorer/json-transformer/-/json-transformer-1.0.2.tgz",
-      "integrity": "sha512-TvLjFICclkbwK/jbed43PWRf6GrVdE2Y1oP8y9gygzSySWEoBJTxJFABAfgbF2HxqBe3+ZesFnnFCYFCyjrARg==",
-      "requires": {
-        "common-path-prefix": "^3.0.0",
-        "jsonata": "^1.8.3",
-        "lodash": "^4.17.19"
       }
     },
     "@biothings-explorer/query_graph_handler": {
@@ -18648,22 +18476,20 @@
       }
     },
     "@biothings-explorer/smartapi-kg": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/@biothings-explorer/smartapi-kg/-/smartapi-kg-3.8.1.tgz",
-      "integrity": "sha512-UuHixjsKV7YnQifNCqV0ozFLsWBkO3BnCiH4gJnuM0rh6vrsiIp1ymrJmp2ZNNId/DnfKsKq98Ks3VsgwOXhsg==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@biothings-explorer/smartapi-kg/-/smartapi-kg-3.9.0.tgz",
+      "integrity": "sha512-PXjx2AAql6wf65ZM5E0OwsVfN1tjWsCtNxoSGo4dmchK+HBE1/kWhCAXxRICSAjTHkcGfoXviJFiZv30lWcpjQ==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@commitlint/cli": "^11.0.0",
         "@commitlint/config-conventional": "^11.0.0",
-        "@types/jest": "^26.0.20",
-        "@types/load-json-file": "^5.1.0",
+        "@types/jest": "^26.0.22",
         "@types/lodash": "^4.14.168",
         "axios": "^0.21.1",
         "camelcase": "^6.2.0",
         "core-js": "^3.9.1",
         "debug": "^4.3.1",
         "husky": "^4.3.8",
-        "jsnetworkx": "^0.3.4",
         "lodash": "^4.17.21"
       },
       "dependencies": {
@@ -19022,11 +18848,30 @@
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
         "camelcase": {
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
           "dev": true
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
         }
       }
     },
@@ -19565,14 +19410,6 @@
         "pretty-format": "^26.0.0"
       }
     },
-    "@types/load-json-file": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@types/load-json-file/-/load-json-file-5.1.0.tgz",
-      "integrity": "sha512-swfGRs+Irsi+iWl16DjfL7fffh9BEwgvH4eptLmrM05iuoI4bTPmNHTepWb2xf84M43/Xd0fs3jze2T3Xzow/g==",
-      "requires": {
-        "load-json-file": "*"
-      }
-    },
     "@types/lodash": {
       "version": "4.14.170",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.170.tgz",
@@ -19802,16 +19639,30 @@
             "json-schema-traverse": "^0.4.1",
             "uri-js": "^4.2.2"
           }
+        },
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
         }
       }
     },
     "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "arr-diff": {
       "version": "4.0.0",
@@ -19943,6 +19794,15 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
+        },
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
         },
         "async": {
           "version": "1.5.2",
@@ -20180,6 +20040,16 @@
             "path-is-inside": "^1.0.1"
           }
         },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
         "latest-version": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
@@ -20410,15 +20280,6 @@
             "signal-exit": "^3.0.2"
           }
         },
-        "ws": {
-          "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-          "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
-          "dev": true,
-          "requires": {
-            "async-limiter": "~1.0.0"
-          }
-        },
         "xdg-basedir": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
@@ -20645,14 +20506,6 @@
         "babel-preset-current-node-syntax": "^1.0.0"
       }
     },
-    "babel-runtime": {
-      "version": "5.8.38",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
-      "integrity": "sha1-HAsC62MxL18If/IEUIJ7QlydTBk=",
-      "requires": {
-        "core-js": "^1.0.0"
-      }
-    },
     "backo2": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
@@ -20750,67 +20603,32 @@
         "debug": "^4.3.1",
         "js-yaml": "^4.0.0",
         "pascal-case": "^3.1.2"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-        },
-        "js-yaml": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "requires": {
-            "argparse": "^2.0.1"
-          }
-        }
       }
     },
     "biomedical_id_resolver": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/biomedical_id_resolver/-/biomedical_id_resolver-3.9.0.tgz",
-      "integrity": "sha512-bV8sR9tZi7h9QBmzIdwfkEseG/CCsOuDdlgfKVMQ9ApPSjdHl10ZPcRnm9qFe8e+22jrK/lLw7zAK/gkE6gYnQ==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/biomedical_id_resolver/-/biomedical_id_resolver-3.10.0.tgz",
+      "integrity": "sha512-lDoH445DiIRkeu0KTureZNgF0EyAIRsqkzaBYuu8XgPalareTHqxwUCRcrjk5gRtel9TYuaNgK2UA/xQQ4sXlw==",
       "requires": {
         "@commitlint/cli": "^11.0.0",
         "@commitlint/config-conventional": "^11.0.0",
-        "axios": "^0.19.2",
-        "biolink-model": "^0.3.1",
+        "axios": "^0.21.1",
+        "biolink-model": "^0.4.0",
         "debug": "^4.3.1",
         "husky": "^4.3.8",
         "lodash": "^4.17.21"
       },
       "dependencies": {
-        "axios": {
-          "version": "0.19.2",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-          "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+        "biolink-model": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/biolink-model/-/biolink-model-0.4.0.tgz",
+          "integrity": "sha512-nu0lJsF1jQYM/82/gOnxXypJ1lO5Ip0WTpXiDQUKxYRqpALpHmExlmXWA4B7Je53BnP9cgZMGlNaP3ZZX1F33w==",
           "requires": {
-            "follow-redirects": "1.5.10"
+            "axios": "^0.21.1",
+            "debug": "^4.3.1",
+            "js-yaml": "^4.0.0",
+            "pascal-case": "^3.1.2"
           }
-        },
-        "follow-redirects": {
-          "version": "1.5.10",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-          "requires": {
-            "debug": "=3.1.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -21109,18 +20927,18 @@
       "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
     },
     "cheerio": {
-      "version": "1.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.5.tgz",
-      "integrity": "sha512-yoqps/VCaZgN4pfXtenwHROTp8NG6/Hlt4Jpz2FEP0ZJQ+ZUkVDd0hAPDNKhj3nakpfPt/CNs57yEtxD1bXQiw==",
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.10.tgz",
+      "integrity": "sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==",
       "dev": true,
       "requires": {
-        "cheerio-select-tmp": "^0.1.0",
-        "dom-serializer": "~1.2.0",
-        "domhandler": "^4.0.0",
-        "entities": "~2.1.0",
-        "htmlparser2": "^6.0.0",
-        "parse5": "^6.0.0",
-        "parse5-htmlparser2-tree-adapter": "^6.0.0"
+        "cheerio-select": "^1.5.0",
+        "dom-serializer": "^1.3.2",
+        "domhandler": "^4.2.0",
+        "htmlparser2": "^6.1.0",
+        "parse5": "^6.0.1",
+        "parse5-htmlparser2-tree-adapter": "^6.0.1",
+        "tslib": "^2.2.0"
       },
       "dependencies": {
         "parse5": {
@@ -21131,17 +20949,17 @@
         }
       }
     },
-    "cheerio-select-tmp": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/cheerio-select-tmp/-/cheerio-select-tmp-0.1.1.tgz",
-      "integrity": "sha512-YYs5JvbpU19VYJyj+F7oYrIE2BOll1/hRU7rEy/5+v9BzkSo3bK81iAeeQEMI92vRIxz677m72UmJUiVwwgjfQ==",
+    "cheerio-select": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.5.0.tgz",
+      "integrity": "sha512-qocaHPv5ypefh6YNxvnbABM07KMxExbtbfuJoIie3iZXX1ERwYmJcIiRrr9H05ucQP1k28dav8rpdDgjQd8drg==",
       "dev": true,
       "requires": {
-        "css-select": "^3.1.2",
-        "css-what": "^4.0.0",
-        "domelementtype": "^2.1.0",
-        "domhandler": "^4.0.0",
-        "domutils": "^2.4.4"
+        "css-select": "^4.1.3",
+        "css-what": "^5.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0",
+        "domutils": "^2.7.0"
       }
     },
     "chokidar": {
@@ -21710,9 +21528,9 @@
           },
           "dependencies": {
             "hosted-git-info": {
-              "version": "2.8.8",
-              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-              "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+              "version": "2.8.9",
+              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+              "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
               "dev": true
             },
             "normalize-package-data": {
@@ -21925,11 +21743,6 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
-    "core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -21967,6 +21780,27 @@
         "log-driver": "^1.2.7",
         "minimist": "^1.2.5",
         "request": "^2.88.2"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        }
       }
     },
     "create-error-class": {
@@ -22003,22 +21837,22 @@
       "dev": true
     },
     "css-select": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-3.1.2.tgz",
-      "integrity": "sha512-qmss1EihSuBNWNNhHjxzxSfJoFBM/lERB/Q4EnsJQQC62R2evJDW481091oAdOr9uh46/0n4nrg0It5cAnj1RA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
+      "integrity": "sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==",
       "dev": true,
       "requires": {
         "boolbase": "^1.0.0",
-        "css-what": "^4.0.0",
-        "domhandler": "^4.0.0",
-        "domutils": "^2.4.3",
+        "css-what": "^5.0.0",
+        "domhandler": "^4.2.0",
+        "domutils": "^2.6.0",
         "nth-check": "^2.0.0"
       }
     },
     "css-what": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-4.0.0.tgz",
-      "integrity": "sha512-teijzG7kwYfNVsUh2H/YN62xW3KK9YhXEgSlbxMlcyjPNvdKJqFx5lrwlJgoFP1ZHlB89iGDlo/JyshKeRhv5A==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
+      "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
       "dev": true
     },
     "cssom": {
@@ -22280,20 +22114,20 @@
       "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q=="
     },
     "dom-serializer": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.2.0.tgz",
-      "integrity": "sha512-n6kZFH/KlCrqs/1GHMOd5i2fd/beQHuehKdWvNNffbGHTr/almdhuVvTVFb3V7fglz+nC50fFusu3lY33h12pA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+      "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
       "dev": true,
       "requires": {
         "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
+        "domhandler": "^4.2.0",
         "entities": "^2.0.0"
       }
     },
     "domelementtype": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
-      "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
       "dev": true
     },
     "domexception": {
@@ -22314,23 +22148,23 @@
       }
     },
     "domhandler": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
-      "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
+      "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
       "dev": true,
       "requires": {
-        "domelementtype": "^2.1.0"
+        "domelementtype": "^2.2.0"
       }
     },
     "domutils": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.4.tgz",
-      "integrity": "sha512-jBC0vOsECI4OMdD0GC9mGn7NXPLb+Qt6KW1YDQzeQYRUFKmNG8lh7mO5HiELfr+lLQE7loDVI4QcAxV80HS+RA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
+      "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
       "dev": true,
       "requires": {
         "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0"
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
       }
     },
     "dot-case": {
@@ -22462,9 +22296,9 @@
       }
     },
     "engine.io-client": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.1.tgz",
-      "integrity": "sha512-oVu9kBkGbcggulyVF0kz6BV3ganqUeqXvD79WOFKa+11oK692w1NyFkuEj4xrkFRpZhn92QOqTk4RQq5LiBXbQ==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.2.tgz",
+      "integrity": "sha512-QEqIp+gJ/kMHeUun7f5Vv3bteRHppHH/FMBQX/esFj/fuYfjyUKWGMo3VCvIP/V8bE9KcjHmRZrhIz2Z9oNsDA==",
       "dev": true,
       "requires": {
         "component-emitter": "~1.3.0",
@@ -22476,7 +22310,7 @@
         "parseqs": "0.0.6",
         "parseuri": "0.0.6",
         "ws": "~7.4.2",
-        "xmlhttprequest-ssl": "~1.5.4",
+        "xmlhttprequest-ssl": "~1.6.2",
         "yeast": "0.1.2"
       },
       "dependencies": {
@@ -22496,10 +22330,11 @@
           "dev": true
         },
         "ws": {
-          "version": "7.4.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
-          "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==",
-          "dev": true
+          "version": "7.4.6",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -22517,9 +22352,9 @@
       }
     },
     "entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
       "dev": true
     },
     "error-ex": {
@@ -22923,6 +22758,11 @@
       "requires": {
         "moment": "^2.11.2"
       }
+    },
+    "file-url": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/file-url/-/file-url-4.0.0.tgz",
+      "integrity": "sha512-vRCdScQ6j3Ku6Kd7W1kZk9c++5SqD6Xz5Jotrjr/nkY714M14RFHy/AAVA2WQvpsqVAVgTbDrYyBpU205F0cLw=="
     },
     "fill-range": {
       "version": "7.0.1",
@@ -23398,9 +23238,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
@@ -23632,9 +23472,9 @@
       "integrity": "sha512-G8tp0wUMI7i8wkMk2xLcEvESg5PiCitFMYgGRc/PwULB0RVhTP5GFdxOwvJwp9XVha8CuS8mnhmE8I/8dx/pbw=="
     },
     "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
     },
     "html-encoding-sniffer": {
       "version": "2.0.1",
@@ -23652,14 +23492,14 @@
       "dev": true
     },
     "htmlparser2": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.0.0.tgz",
-      "integrity": "sha512-numTQtDZMoh78zJpaNdJ9MXb2cv5G3jwUoe3dMQODubZvLoGvTE/Ofp6sHvH8OGKcN/8A47pGLi/k58xHP/Tfw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
       "dev": true,
       "requires": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.0.0",
-        "domutils": "^2.4.4",
+        "domutils": "^2.5.2",
         "entities": "^2.0.0"
       }
     },
@@ -24160,7 +24000,8 @@
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
     },
     "is-valid-path": {
       "version": "0.1.1",
@@ -25474,12 +25315,11 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       }
     },
     "jsbn": {
@@ -25540,10 +25380,11 @@
           }
         },
         "ws": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
-          "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ==",
-          "dev": true
+          "version": "7.5.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
+          "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -25552,24 +25393,6 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
-    },
-    "jsnetworkx": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/jsnetworkx/-/jsnetworkx-0.3.4.tgz",
-      "integrity": "sha1-HAAl35QgjOtcxZ5lj5qb9f709vQ=",
-      "requires": {
-        "babel-runtime": "^5",
-        "lodash": "^3.3.1",
-        "through": "^2.3.6",
-        "tiny-sprintf": "^0.3.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-        }
-      }
     },
     "json-buffer": {
       "version": "3.0.0",
@@ -25630,9 +25453,9 @@
       }
     },
     "jsonata": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/jsonata/-/jsonata-1.8.4.tgz",
-      "integrity": "sha512-OqzmM5IICtm/687zckG5BROZzInGCEuKojpYs48H8RnkII8Np+o912ryvhnYwsRrSI24TQRG/qqrSwBuaneDbg=="
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/jsonata/-/jsonata-1.8.5.tgz",
+      "integrity": "sha512-ilDyTBkg6qhNoNVr8PUPzz5GYvRK+REKOM5MdOGzH2y6V4yvPRMegSvbZLpbTtI0QAgz09QM7drDhSHUlwp9pA=="
     },
     "jsonfile": {
       "version": "6.1.0",
@@ -25649,14 +25472,14 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
     },
     "jsonpath": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.1.0.tgz",
-      "integrity": "sha512-CZHwa1sZOf42qkIyK7evwToFXeTB4iplbl6Z9CVwU0wmBQPffL6gtYJXCoeciJoZENMuzaidPjhp2iOLRei4wQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.1.1.tgz",
+      "integrity": "sha512-l6Cg7jRpixfbgoWgkrl77dgEj8RPvND0wMH6TwQmi9Qs4TFfS9u5cUFnbeKTwj5ga5Y3BTGGNI28k117LJ009w==",
       "dev": true,
       "requires": {
         "esprima": "1.2.2",
         "static-eval": "2.0.2",
-        "underscore": "1.7.0"
+        "underscore": "1.12.1"
       },
       "dependencies": {
         "esprima": {
@@ -25753,6 +25576,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "parse-json": "^2.2.0",
@@ -25765,6 +25589,7 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
           "requires": {
             "error-ex": "^1.2.0"
           }
@@ -25773,6 +25598,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
           "requires": {
             "is-utf8": "^0.2.0"
           }
@@ -25872,6 +25698,14 @@
         "fecha": "^4.2.0",
         "ms": "^2.1.1",
         "triple-beam": "^1.3.0"
+      }
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "loud-rejection": {
@@ -25993,9 +25827,9 @@
       },
       "dependencies": {
         "hosted-git-info": {
-          "version": "3.0.7",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.7.tgz",
-          "integrity": "sha512-fWqc0IcuXs+BmE9orLDyVykAG9GJtGLGuZAAqgcckPgv5xad4AcXGIv8galtQvlwutxSlaMcdw7BUtq2EIvqCQ==",
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.8.tgz",
+          "integrity": "sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -26373,15 +26207,15 @@
       "dev": true
     },
     "normalize-url": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
       "dev": true
     },
     "npm": {
-      "version": "6.14.12",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.12.tgz",
-      "integrity": "sha512-La0TNNm1TLYaSeOyit+p3xGTRYYRsHae6/RG69MVXurZsWna9jccPP7FOi/u7V9WdiCV5OOojrfMD+WstO5MZQ==",
+      "version": "6.14.14",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.14.tgz",
+      "integrity": "sha512-4TnYPV3rvwk9m92ON0iFrdXtRyMhrNkGdI8sr3dy1HVE3pVNxR9FyWYbjAw/HjfmHvmHUbxTVbmjAMv8NhIa6Q==",
       "requires": {
         "abbrev": "~1.1.1",
         "ansicolors": "~0.3.2",
@@ -26413,7 +26247,7 @@
         "glob": "^7.1.6",
         "graceful-fs": "^4.2.4",
         "has-unicode": "~2.0.1",
-        "hosted-git-info": "^2.8.8",
+        "hosted-git-info": "^2.8.9",
         "iferr": "^1.0.2",
         "imurmurhash": "*",
         "infer-owner": "^1.0.4",
@@ -26490,9 +26324,9 @@
         "slide": "~1.1.6",
         "sorted-object": "~2.0.1",
         "sorted-union-stream": "~2.1.3",
-        "ssri": "^6.0.1",
+        "ssri": "^6.0.2",
         "stringify-package": "^1.0.1",
-        "tar": "^4.4.13",
+        "tar": "^4.4.15",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
         "uid-number": "0.0.6",
@@ -27530,7 +27364,7 @@
           "bundled": true
         },
         "hosted-git-info": {
-          "version": "2.8.8",
+          "version": "2.8.9",
           "bundled": true
         },
         "http-cache-semantics": {
@@ -28934,7 +28768,7 @@
           }
         },
         "ssri": {
-          "version": "6.0.1",
+          "version": "6.0.2",
           "bundled": true,
           "requires": {
             "figgy-pudding": "^3.5.1"
@@ -29051,7 +28885,7 @@
           }
         },
         "tar": {
-          "version": "4.4.13",
+          "version": "4.4.15",
           "bundled": true,
           "requires": {
             "chownr": "^1.1.1",
@@ -29865,9 +29699,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -29900,17 +29734,20 @@
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
     },
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
       "requires": {
         "pinkie": "^2.0.0"
       }
@@ -31656,11 +31493,6 @@
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
       "dev": true
     },
-    "tiny-sprintf": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/tiny-sprintf/-/tiny-sprintf-0.3.0.tgz",
-      "integrity": "sha1-QnL9XB0vkoByI/wW1yj98wWVoz4="
-    },
     "tmp": {
       "version": "0.0.28",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
@@ -31774,9 +31606,9 @@
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
     },
     "trim-newlines": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
-      "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw=="
     },
     "trim-off-newlines": {
       "version": "1.0.1",
@@ -31897,9 +31729,9 @@
       }
     },
     "underscore": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==",
       "dev": true
     },
     "union-value": {
@@ -32171,6 +32003,14 @@
         "makeerror": "1.0.x"
       }
     },
+    "warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "webidl-conversions": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
@@ -32361,6 +32201,15 @@
         "typedarray-to-buffer": "^3.1.5"
       }
     },
+    "ws": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.3.tgz",
+      "integrity": "sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==",
+      "dev": true,
+      "requires": {
+        "async-limiter": "~1.0.0"
+      }
+    },
     "xdg-basedir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
@@ -32380,9 +32229,9 @@
       "dev": true
     },
     "xmlhttprequest-ssl": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
-      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz",
+      "integrity": "sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q==",
       "dev": true
     },
     "xtend": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "express": "^4.17.1",
         "express-rate-limit": "^5.2.6",
         "express-winston": "^4.1.0",
-        "file-url": "^4.0.0",
         "helmet": "^4.4.1",
         "husky": "^4.3.8",
         "js-yaml": "^4.1.0",
@@ -5767,17 +5766,6 @@
       "integrity": "sha512-VYb3HZ/GiAGUCrfeakO8Mp54YGswNUHvL7P09WQcXAJNSj3iQ5QraYSp3cIn1MUyw6uzfgN/EFOarCNa4JvUHQ==",
       "dependencies": {
         "moment": "^2.11.2"
-      }
-    },
-    "node_modules/file-url": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/file-url/-/file-url-4.0.0.tgz",
-      "integrity": "sha512-vRCdScQ6j3Ku6Kd7W1kZk9c++5SqD6Xz5Jotrjr/nkY714M14RFHy/AAVA2WQvpsqVAVgTbDrYyBpU205F0cLw==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/fill-range": {
@@ -22758,11 +22746,6 @@
       "requires": {
         "moment": "^2.11.2"
       }
-    },
-    "file-url": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/file-url/-/file-url-4.0.0.tgz",
-      "integrity": "sha512-vRCdScQ6j3Ku6Kd7W1kZk9c++5SqD6Xz5Jotrjr/nkY714M14RFHy/AAVA2WQvpsqVAVgTbDrYyBpU205F0cLw=="
     },
     "fill-range": {
       "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "openapi-validator-middleware": "^3.2.2",
     "redis": "^3.1.1",
     "snake-case": "^3.0.4",
+    "warning": "^4.0.3",
     "winston": "^3.3.3",
     "winston-daily-rotate-file": "^4.5.1"
   },

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "express": "^4.17.1",
     "express-rate-limit": "^5.2.6",
     "express-winston": "^4.1.0",
+    "file-url": "^4.0.0",
     "helmet": "^4.4.1",
     "husky": "^4.3.8",
     "js-yaml": "^4.1.0",
@@ -65,6 +66,7 @@
     "openapi-validator-middleware": "^3.2.2",
     "redis": "^3.1.1",
     "snake-case": "^3.0.4",
+    "valid-url": "^1.0.9",
     "warning": "^4.0.3",
     "winston": "^3.3.3",
     "winston-daily-rotate-file": "^4.5.1"

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "express-winston": "^4.1.0",
     "helmet": "^4.4.1",
     "husky": "^4.3.8",
+    "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
     "node-cron": "^2.0.3",
     "npm": "^6.14.12",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@biothings-explorer/bte-trapi",
   "version": "2.8.1",
-  "description": "App performing single hop query for BioThings Explorer",
+  "description": "BioThings Explorer's TRAPI Knowledgebase Query API",
   "main": "src/server.js",
   "scripts": {
     "build": "echo 'no build needed'",
@@ -30,7 +30,7 @@
     "hop",
     "query"
   ],
-  "author": "jiwen xin",
+  "author": "BioThings Team",
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/biothings/BioThings_Explorer_TRAPI/issues"
@@ -45,8 +45,8 @@
     "supertest": "^6.1.3"
   },
   "dependencies": {
-    "@biothings-explorer/query_graph_handler": "^1.17.5",
-    "@biothings-explorer/smartapi-kg": "^3.8.1",
+    "@biothings-explorer/query_graph_handler": "^1.18.0",
+    "@biothings-explorer/smartapi-kg": "^3.9.0",
     "axios": "^0.21.1",
     "body-parser": "^1.19.0",
     "compression": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "express": "^4.17.1",
     "express-rate-limit": "^5.2.6",
     "express-winston": "^4.1.0",
-    "file-url": "^4.0.0",
     "helmet": "^4.4.1",
     "husky": "^4.3.8",
     "js-yaml": "^4.1.0",

--- a/src/controllers/cron/update_local_smartapi.js
+++ b/src/controllers/cron/update_local_smartapi.js
@@ -223,6 +223,7 @@ const getAPIOverrides = async (data) => {
         };
         const index = overrides.conf.only_overrides ? -1 : data.hits.findIndex(hit => hit._id === id);
         if (index === -1) {
+            debug(`WARN: Overridden API ID ${id} not recognized, appending as new API hit.`);
             data.hits.push(override);
         } else {
             data.hits[index] = override;

--- a/src/controllers/cron/update_local_smartapi.js
+++ b/src/controllers/cron/update_local_smartapi.js
@@ -1,4 +1,5 @@
 const debug = require("debug")("bte:biothings-explorer-trapi:cron");
+const warning = require("warning");
 const axios = require("axios");
 const fs = require("fs");
 var path = require('path');
@@ -223,7 +224,7 @@ const getAPIOverrides = async (data) => {
         };
         const index = overrides.conf.only_overrides ? -1 : data.hits.findIndex(hit => hit._id === id);
         if (index === -1) {
-            debug(`WARN: Overridden API ID ${id} not recognized, appending as new API hit.`);
+            warning(index !== -1, `Overridden API ID ${id} not recognized, appending as new API hit.`);
             data.hits.push(override);
         } else {
             data.hits[index] = override;

--- a/src/routes/v1/query_v1.js
+++ b/src/routes/v1/query_v1.js
@@ -13,7 +13,7 @@ class V1RouteQuery {
             try {
                 utils.validateWorkflow(req.body.workflow);
                 const queryGraph = req.body.message.query_graph;
-                const handler = new TRAPIGraphHandler.TRAPIQueryHandler({ apiNames: config.API_LIST, caching: req.query.caching }, smartAPIPath, predicatesPath);
+                const handler = new TRAPIGraphHandler.TRAPIQueryHandler({ apiList: config.API_LIST, caching: req.query.caching }, smartAPIPath, predicatesPath);
                 handler.setQueryGraph(queryGraph);
                 await handler.query();
                 res.setHeader('Content-Type', 'application/json');


### PR DESCRIPTION
*(continuation of #255)*

This change logs a warning when retrieving an API override for an API not already in the SmartAPI specs (which is then appends the overridden API as a new `hit`).