### PR TITLE
update API list to add iDISK, other Automat APIs

### DIFF
--- a/src/routes/v1/config.js
+++ b/src/routes/v1/config.js
@@ -1,4 +1,21 @@
 exports.API_LIST = [
+    // external APIs annotated with SmartAPI x-bte
+    {
+        id: 'd22b657426375a5295e7da8a303b9893',
+        name: 'BioLink API'
+    },
+    {
+        id: '43af91b3d7cae43591083bff9d75c6dd',
+        name: 'EBI Proteins API'
+    },
+    {
+        id: '1ad2cba40cb25cd70d00aa8fba9cfaf3',
+        name: 'LINCS Data Portal API'
+    },
+    {
+        id: 'dca415f2d792976af9d642b7e73f7a41',
+        name: 'LitVar API'
+    },
     {
         id: '1f277e1563fcfd124bfae2cc3c4bcdec',
         name: 'QuickGO API'
@@ -7,61 +24,10 @@ exports.API_LIST = [
         id: '1c056ffc7ed0dd1229e71c4752239465',
         name: 'Ontology Lookup Service API'
     },
+    // "pending" BioThings APIs
     {
-        id: 'dca415f2d792976af9d642b7e73f7a41',
-        name: 'LitVar API'
-    },
-    {
-        id: 'a5b0ec6bfde5008984d4b6cde402d61f',
-        name: 'Human Phenotype Ontology API'
-    },
-    {
-        id: 'ec6d76016ef40f284359d17fbf78df20',
-        name: 'UBERON Ontology API'
-    },
-    {
-        id: '671b45c0301c8624abbd26ae78449ca2',
-        name: 'MyDisease.info API'
-    },
-    {
-        id: '09c8782d9f4027712e65b95424adba79',
-        name: 'MyVariant.info API'
-    },
-    {
-        id: '59dce17363dce279d389100834e43648',
-        name: 'MyGene.info API'
-    },
-    {
-        id: 'ed0ee52921c7cbce24033ffd1369922e',
-        name: 'SEMMED Disease API'
-    },
-    {
-        id: '8f08d1446e0bb9c2b323713ce83e2bd3',
-        name: 'MyChem.info API'
-    },
-    {
-        id: '0c9f1154a1986f1774057af4c1caa5b2',
-        name: 'SEMMED Anatomy API'
-    },
-    {
-        id: '81955d376a10505c1c69cd06dbda3047',
-        name: 'SEMMED Gene API'
-    },
-    {
-        id: '2dffb89df7f970b6a07e816e255d33ec',
-        name: 'SEMMED Phenotype API'
-    },
-    {
-        id: '77ed27f111262d0289ed4f4071faa619',
-        name: 'MGIgene2phenotype API'
-    },
-    {
-        id: '5a7d625d50fc518d33db48cf39ce9b30',
-        name: 'SEMMED Biological Process API'
-    },
-    {
-        id: '7c07eca4ef5ceb532d06c0180e86aedd',
-        name: 'SEMMED Chemical API'
+        id: 'e3edd325c76f2992a111b43a907a4870',
+        name: 'BioThings DGIdb API'
     },
     {
         id: 'a7f784626a426d054885a5f33f17d3f8',
@@ -76,60 +42,97 @@ exports.API_LIST = [
         name: 'Gene Ontology Biological Process API'
     },
     {
-        id: 'd86a24f6027ffe778f84ba10a7a1861a',
-        name: 'Clinical Risk KP API'
+        id: 'f339b28426e7bf72028f60feefcd7465',
+        name: 'Gene Ontology Cellular Component API'
     },
     {
         id: '34bad236d77bea0a0ee6c6cba5be54a6',
         name: 'Gene Ontology Molecular Activity API'
     },
     {
-        id: 'f339b28426e7bf72028f60feefcd7465',
-        name: 'Gene Ontology Cellular Component API'
+        id: 'a5b0ec6bfde5008984d4b6cde402d61f',
+        name: 'Human Phenotype Ontology API'
     },
     {
-        id: 'e3edd325c76f2992a111b43a907a4870',
-        name: 'BioThings DGIdb API'
+        id: '77ed27f111262d0289ed4f4071faa619',
+        name: 'MGIgene2phenotype API'
     },
     {
-        id: '978fe380a147a8641caf72320862697b',
-        name: 'Text Mining Targeted Association API'
+        id: 'ec6d76016ef40f284359d17fbf78df20',
+        name: 'UBERON Ontology API'
+    },
+    // Core BioThings APIs
+    {
+        id: '8f08d1446e0bb9c2b323713ce83e2bd3',
+        name: 'MyChem.info API'
+    },
+    {
+        id: '671b45c0301c8624abbd26ae78449ca2',
+        name: 'MyDisease.info API'
+    },
+    {
+        id: '59dce17363dce279d389100834e43648',
+        name: 'MyGene.info API'
+    },
+    {
+        id: '09c8782d9f4027712e65b95424adba79',
+        name: 'MyVariant.info API'
+    },
+    // SEMMED BioThings APIs
+    {
+        id: '0c9f1154a1986f1774057af4c1caa5b2',
+        name: 'SEMMED Anatomy API'
+    },
+    {
+        id: '5a7d625d50fc518d33db48cf39ce9b30',
+        name: 'SEMMED Biological Process API'
+    },
+    {
+        id: '7c07eca4ef5ceb532d06c0180e86aedd',
+        name: 'SEMMED Chemical API'
+    },
+    {
+        id: 'ed0ee52921c7cbce24033ffd1369922e',
+        name: 'SEMMED Disease API'
+    },
+    {
+        id: '81955d376a10505c1c69cd06dbda3047',
+        name: 'SEMMED Gene API'
+    },
+    {
+        id: '2dffb89df7f970b6a07e816e255d33ec',
+        name: 'SEMMED Phenotype API'
+    },
+    // Multiomics Provider collab
+    {
+        id: 'd86a24f6027ffe778f84ba10a7a1861a',
+        name: 'Clinical Risk KP API'
     },
     {
         id: '02af7d098ab304e80d6f4806c3527027',
         name: 'Multiomics Wellness KP API'
     },
+    // Text Mining Provider collab
     {
-        id: 'd22b657426375a5295e7da8a303b9893',
-        name: 'BioLink API'
+        id: '978fe380a147a8641caf72320862697b',
+        name: 'Text Mining Targeted Association API'
     },
-    {
-        id: '1ad2cba40cb25cd70d00aa8fba9cfaf3',
-        name: 'LINCS Data Portal API'
-    },
-    {
-        id: '43af91b3d7cae43591083bff9d75c6dd',
-        name: 'EBI Proteins API'
-    },
-    {
-        id: 'bee0cc86f86d88b83f613b674e2bd92e',
-        name: 'Automat IntAct (trapi v-1.1.2)'
-    },
+    // Automat APIs
     {
         id: '0a93684206ec6a13812ff2867a445c4e',
         name: 'Automat Cord19 (trapi v-1.1.2)'
+    },
+    {
+        id: '1fd2f4cc6b3b6b1f7cda594b00607270',
+        name: 'Automat Foodb (trapi v-1.1.2)'
     },
     {
         id: 'c8b1619535bd598406049f4dc51e1702',
         name: 'Automat Gtopdb (trapi v-1.1.2)'
     },
     {
-        id: '994a667dafe2e2c1d42a5390a6fba9aa',
-        name: 'Automat Uberongraph (trapi v-1.1.2)'
-    },
-    {
-        id: '2c9fff2f09c71302659faeb515bbb2b8',
-        name: 'Automat Human GOA (trapi v-1.1.2)'
+        id: '3a8ad755bbd6f4fdfc0a18c8020d6d58',
+        name: 'Automat Hetio (trapi v-1.1.2)'
     },
     {
         id: '255ea57924924b721919b9ee17a07894',
@@ -140,8 +143,12 @@ exports.API_LIST = [
         name: 'Automat HMDB (trapi v-1.1.2)'
     },
     {
-        id: '3a8ad755bbd6f4fdfc0a18c8020d6d58',
-        name: 'Automat Hetio (trapi v-1.1.2)'
+        id: '2c9fff2f09c71302659faeb515bbb2b8',
+        name: 'Automat Human GOA (trapi v-1.1.2)'
+    },
+    {
+        id: 'bee0cc86f86d88b83f613b674e2bd92e',
+        name: 'Automat IntAct (trapi v-1.1.2)'
     },
     {
         id: 'c3e55e3a28cf14e147b55e6e09b32b9b',
@@ -152,8 +159,8 @@ exports.API_LIST = [
         name: 'Automat Pharos (trapi v-1.1.2)'
     },
     {
-        id: '1fd2f4cc6b3b6b1f7cda594b00607270',
-        name: 'Automat Foodb (trapi v-1.1.2)'
+        id: '994a667dafe2e2c1d42a5390a6fba9aa',
+        name: 'Automat Uberongraph (trapi v-1.1.2)'
     },
     // other Automat APIs we could try out
     // ask: is Automat CTD still up / valid?
@@ -179,20 +186,21 @@ exports.API_LIST = [
     //     id: 'bd612e18f86d9097b02c0d83344b46b7',
     //     name: 'Automat CTD (trapi v-1.1.2)'
     // },
+    // Clinical-data-based APIs from other Translator teams
     {
-        id: '65292eac9a88e3a895be21f19b554767',
-        name: 'ICEES COVID-19 Instance API'
+        id: '70117385218edc9bc01633829011dfcf',
+        name: 'Columbia Open Health Data (COHD)'
     },
     {
         id: '0864c0912390d0876c3c34a00acb5c3b',
         name: 'ICEES Asthma Instance API'
     },
     {
-        id: '9dd890397a7b8d98fbe247d56cac2b8f',
-        name: 'ICEES DILI Instance API'
+        id: '65292eac9a88e3a895be21f19b554767',
+        name: 'ICEES COVID-19 Instance API'
     },
     {
-        id: '70117385218edc9bc01633829011dfcf',
-        name: 'Columbia Open Health Data (COHD)'
+        id: '9dd890397a7b8d98fbe247d56cac2b8f',
+        name: 'ICEES DILI Instance API'
     },
 ];

--- a/src/routes/v1/config.js
+++ b/src/routes/v1/config.js
@@ -1,8 +1,8 @@
 exports.API_LIST = [
     'QuickGO API', //1f277e1563fcfd124bfae2cc3c4bcdec
     'Ontology Lookup Service API', //1c056ffc7ed0dd1229e71c4752239465
-    'CTD API', //?
-    // 'OpenTarget API',
+    // 'CTD API',  // has no smartapi registration right now, registry github has an old entry...
+    // 'OpenTarget API',  // defunct api, outdated smartapi registration
     'LitVar API', //dca415f2d792976af9d642b7e73f7a41
     'Human Phenotype Ontology API', //a5b0ec6bfde5008984d4b6cde402d61f
     'UBERON Ontology API', //ec6d76016ef40f284359d17fbf78df20
@@ -24,26 +24,32 @@ exports.API_LIST = [
     'Gene Ontology Molecular Activity API', //34bad236d77bea0a0ee6c6cba5be54a6
     'Gene Ontology Cellular Component API', //f339b28426e7bf72028f60feefcd7465
     'BioThings DGIdb API', //e3edd325c76f2992a111b43a907a4870
-    // 'Text Mining CO-OCCURRENCE API',
+    // 'Text Mining CO-OCCURRENCE API',   // removing since too many results when queried
     'Text Mining Targeted Association API', //978fe380a147a8641caf72320862697b
     'Multiomics Wellness KP API', //02af7d098ab304e80d6f4806c3527027
     'BioLink API', //d22b657426375a5295e7da8a303b9893
     'LINCS Data Portal API', //1ad2cba40cb25cd70d00aa8fba9cfaf3
     'EBI Proteins API', //43af91b3d7cae43591083bff9d75c6dd
-    'Automat IntAct (trapi v-1.1.0)', //bee0cc86f86d88b83f613b674e2bd92e
-    'Automat Cord19 Scibite (trapi v-1.1.0)', //4d2dfc41e256dc6e652e648eee7829a9
-    'Automat Gtopdb (trapi v-1.1.0)', //c8b1619535bd598406049f4dc51e1702
-    'Automat KEGG', //?
-    'Automat Cord19 Scigraph (trapi v-1.1.0)', //4d242ec3f86786729f109b0e9088a0d7
-    'Automat Uberongraph (trapi v-1.1.0)', //994a667dafe2e2c1d42a5390a6fba9aa
-    'Automat Human GOA (trapi v-1.1.0)', //2c9fff2f09c71302659faeb515bbb2b8
-    'Automat HGNC (trapi v-1.1.0)', //255ea57924924b721919b9ee17a07894
-    'Automat HMDB (trapi v-1.1.0)', //c3e55e3a28cf14e147b55e6e09b32b9b
-    'Automat Hetio (trapi v-1.1.0)', //3a8ad755bbd6f4fdfc0a18c8020d6d58
-    'Automat Panther (trapi v-1.1.0)', //c3e55e3a28cf14e147b55e6e09b32b9b
-    'Automat Pharos (trapi v-1.1.0)', //e0031784afd7cb4e97e266d11df3a9e4
-    'Automat Chembio', //?
-    'Automat Foodb (trapi v-1.1.0)', //1fd2f4cc6b3b6b1f7cda594b00607270
+    'Automat IntAct (trapi v-1.1.2)', //bee0cc86f86d88b83f613b674e2bd92e
+    'Automat Gtopdb (trapi v-1.1.2)', //c8b1619535bd598406049f4dc51e1702
+    'Automat Cord19 (trapi v-1.1.2)', //0a93684206ec6a13812ff2867a445c4e
+    'Automat Uberongraph (trapi v-1.1.2)', //994a667dafe2e2c1d42a5390a6fba9aa
+    'Automat Human GOA (trapi v-1.1.2)', //2c9fff2f09c71302659faeb515bbb2b8
+    'Automat HGNC (trapi v-1.1.2)', //255ea57924924b721919b9ee17a07894
+    'Automat HMDB (trapi v-1.1.2)', //c3e55e3a28cf14e147b55e6e09b32b9b
+    'Automat Hetio (trapi v-1.1.2)', //3a8ad755bbd6f4fdfc0a18c8020d6d58
+    'Automat Panther (trapi v-1.1.2)', //c3e55e3a28cf14e147b55e6e09b32b9b
+    'Automat Pharos (trapi v-1.1.2)', //e0031784afd7cb4e97e266d11df3a9e4
+    'Automat Foodb (trapi v-1.1.2)', //1fd2f4cc6b3b6b1f7cda594b00607270
+    // other Automat APIs we could try out
+    // ask: is Automat CTD still up / valid?
+    //      would Automat Viral Proteome, Chemical normalization, Ontological Hierarchy be useful?
+    //      could we use Automat Biolink or Human GOA rather than our APIs?
+    // 'Automat GTEx (trapi v-1.1.2)', //62811dab25864feb191aad0b23503813
+    // 'Automat Robokop KG (trapi v-1.1.2)', //4f94c54ada189ecfe08491f662986fd6
+    // 'Automat Textmining KP (trapi v-1.1.2)', //7deb474184d551fdfa69c28a9bc46073
+    // 'Automat Viral Proteome (trapi v-1.1.2)', //3437ede0d451c90f67097c56b230e022
+    // 'Automat CTD (trapi v-1.1.2)', //bd612e18f86d9097b02c0d83344b46b7
 
     'ICEES COVID-19 Instance API', //65292eac9a88e3a895be21f19b554767
     'ICEES Asthma Instance API', //0864c0912390d0876c3c34a00acb5c3b

--- a/src/routes/v1/config.js
+++ b/src/routes/v1/config.js
@@ -30,6 +30,10 @@ exports.API_LIST = [
         name: 'BioThings DGIdb API'
     },
     {
+        id: '32f36164fabed5d3abe6c2fd899c9418',
+        name: 'BioThings iDISK API'
+    },
+    {
         id: 'a7f784626a426d054885a5f33f17d3f8',
         name: 'DISEASES API'
     },
@@ -113,18 +117,42 @@ exports.API_LIST = [
         name: 'Multiomics Wellness KP API'
     },
     // Text Mining Provider collab
+    // - removed Text Mining Co-occurrence API since there were issues using it with BTE (too many answers)
     {
         id: '978fe380a147a8641caf72320862697b',
         name: 'Text Mining Targeted Association API'
     },
     // Automat APIs
     {
+    // this API overlaps with our Biolink API registration, but we have bugs with our ingest...
+    //   this may have been updated more recently / transformed data into TRAPI format
+        id: '05a5f5d18b4f2c532367561778571c9a',
+        name: 'Automat Biolink (trapi v-1.1.2)'
+    },
+    {
+        id: 'b0b36734630fdeb93252ebab7939535e',
+        name: 'Automat Chemical normalization (trapi v-1.1.2)'
+    },
+    {
         id: '0a93684206ec6a13812ff2867a445c4e',
         name: 'Automat Cord19 (trapi v-1.1.2)'
     },
     {
+        id: 'a192b537c4113cc585088511574dbe64',
+        name: 'Automat Covidkop KG (trapi v-1.1.2)'
+    },
+    {
+    // this may overlap with info we have in MyDisease, MyChem, and other APIs...
+        id: 'bd612e18f86d9097b02c0d83344b46b7',
+        name: 'Automat CTD (trapi v-1.1.2)'
+    },
+    {
         id: '1fd2f4cc6b3b6b1f7cda594b00607270',
         name: 'Automat Foodb (trapi v-1.1.2)'
+    },
+    {
+        id: '62811dab25864feb191aad0b23503813',
+        name: 'Automat GTEx (trapi v-1.1.2)'
     },
     {
         id: 'c8b1619535bd598406049f4dc51e1702',
@@ -142,13 +170,19 @@ exports.API_LIST = [
         id: 'c3e55e3a28cf14e147b55e6e09b32b9b',
         name: 'Automat HMDB (trapi v-1.1.2)'
     },
-    {
+    {  
+    // this API overlaps with our BioThings GO APIs, but
+    //   may have been updated more recently / transformed data into TRAPI format
         id: '2c9fff2f09c71302659faeb515bbb2b8',
         name: 'Automat Human GOA (trapi v-1.1.2)'
     },
     {
         id: 'bee0cc86f86d88b83f613b674e2bd92e',
         name: 'Automat IntAct (trapi v-1.1.2)'
+    },
+    {
+        id: '2bb65b7ea0cd1d40f4e9147836b750e2',
+        name: 'Automat Ontological Hierarchy (trapi v-1.1.2)'
     },
     {
         id: 'c3e55e3a28cf14e147b55e6e09b32b9b',
@@ -159,33 +193,23 @@ exports.API_LIST = [
         name: 'Automat Pharos (trapi v-1.1.2)'
     },
     {
+        id: '4f94c54ada189ecfe08491f662986fd6',
+        name: 'Automat Robokop KG (trapi v-1.1.2)'
+    },
+    {
+    // not sure if this API overlaps with Text Mining Targeted Association API or
+    //   Text Mining Co-occurrrence API...
+        id: '7deb474184d551fdfa69c28a9bc46073',
+        name: 'Automat Textmining KP (trapi v-1.1.2)'
+    },
+    {
         id: '994a667dafe2e2c1d42a5390a6fba9aa',
         name: 'Automat Uberongraph (trapi v-1.1.2)'
     },
-    // other Automat APIs we could try out
-    // ask: is Automat CTD still up / valid?
-    //      would Automat Viral Proteome, Chemical normalization, Ontological Hierarchy be useful?
-    //      could we use Automat Biolink or Human GOA rather than our APIs?
-    // {
-    //     id: '62811dab25864feb191aad0b23503813',
-    //     name: 'Automat GTEx (trapi v-1.1.2)'
-    // },
-    // {
-    //     id: '4f94c54ada189ecfe08491f662986fd6',
-    //     name: 'Automat Robokop KG (trapi v-1.1.2)'
-    // },
-    // {
-    //     id: '7deb474184d551fdfa69c28a9bc46073',
-    //     name: 'Automat Textmining KP (trapi v-1.1.2)'
-    // },
-    // {
-    //     id: '3437ede0d451c90f67097c56b230e022',
-    //     name: 'Automat Viral Proteome (trapi v-1.1.2)'
-    // },
-    // {
-    //     id: 'bd612e18f86d9097b02c0d83344b46b7',
-    //     name: 'Automat CTD (trapi v-1.1.2)'
-    // },
+    {
+        id: '3437ede0d451c90f67097c56b230e022',
+        name: 'Automat Viral Proteome (trapi v-1.1.2)'
+    },
     // Clinical-data-based APIs from other Translator teams
     {
         id: '70117385218edc9bc01633829011dfcf',

--- a/src/routes/v1/config.js
+++ b/src/routes/v1/config.js
@@ -24,7 +24,7 @@ exports.API_LIST = [
         id: '1c056ffc7ed0dd1229e71c4752239465',
         name: 'Ontology Lookup Service API'
     },
-    // "pending" BioThings APIs
+    // "pending" BioThings APIs, annotated by x-bte
     {
         id: 'e3edd325c76f2992a111b43a907a4870',
         name: 'BioThings DGIdb API'
@@ -65,7 +65,7 @@ exports.API_LIST = [
         id: 'ec6d76016ef40f284359d17fbf78df20',
         name: 'UBERON Ontology API'
     },
-    // Core BioThings APIs
+    // Core BioThings APIs, annotated with x-bte
     {
         id: '8f08d1446e0bb9c2b323713ce83e2bd3',
         name: 'MyChem.info API'
@@ -82,7 +82,7 @@ exports.API_LIST = [
         id: '09c8782d9f4027712e65b95424adba79',
         name: 'MyVariant.info API'
     },
-    // SEMMED BioThings APIs
+    // SEMMED BioThings APIs, annotated with x-bte
     {
         id: '0c9f1154a1986f1774057af4c1caa5b2',
         name: 'SEMMED Anatomy API'
@@ -107,7 +107,7 @@ exports.API_LIST = [
         id: '2dffb89df7f970b6a07e816e255d33ec',
         name: 'SEMMED Phenotype API'
     },
-    // Multiomics Provider collab
+    // Multiomics Provider collab, annotated with x-bte
     {
         id: 'd86a24f6027ffe778f84ba10a7a1861a',
         name: 'Clinical Risk KP API'
@@ -116,13 +116,13 @@ exports.API_LIST = [
         id: '02af7d098ab304e80d6f4806c3527027',
         name: 'Multiomics Wellness KP API'
     },
-    // Text Mining Provider collab
+    // Text Mining Provider collab, annotated with x-bte
     // - removed Text Mining Co-occurrence API since there were issues using it with BTE (too many answers)
     {
         id: '978fe380a147a8641caf72320862697b',
         name: 'Text Mining Targeted Association API'
     },
-    // Automat APIs
+    // Automat APIs, ingested through TRAPI
     {
     // this API overlaps with our Biolink API registration, but we have bugs with our ingest...
     //   this may have been updated more recently / transformed data into TRAPI format
@@ -210,7 +210,7 @@ exports.API_LIST = [
         id: '3437ede0d451c90f67097c56b230e022',
         name: 'Automat Viral Proteome (trapi v-1.1.2)'
     },
-    // Clinical-data-based APIs from other Translator teams
+    // Clinical-data-based APIs from other Translator teams, ingested through TRAPI
     {
         id: '70117385218edc9bc01633829011dfcf',
         name: 'Columbia Open Health Data (COHD)'


### PR DESCRIPTION
EDIT: defunct, this PR does still address #256 

> currently BTE's querying of Automat APIs isn't working since:
> - they changed their names
> - some APIs were recently taken offline
> 
> This PR addresses this problem. Related to #256 
> 
> It also adds comments about other Automat APIs we may want to consider adding (or using to replace Service Provider APIs...)