### PR TITLE
feat: pass optional redis password via env

### DIFF
--- a/src/utils/cache/redis-client.js
+++ b/src/utils/cache/redis-client.js
@@ -6,12 +6,12 @@ let client;
 const enableRedis = (!(process.env.REDIS_HOST === undefined)) && (!(process.env.REDIS_PORT === undefined));
 
 if (enableRedis === true) {
-    client = redis.createClient(
-        {
-            port: process.env.REDIS_PORT,
-            host: process.env.REDIS_HOST
-        }
-    )
+    const details = {
+        port: process.env.REDIS_PORT,
+        host: process.env.REDIS_HOST,
+    };
+    if (process.env.REDIS_PASSWORD) { details.password = process.env.REDIS_PASSWORD }
+    client = redis.createClient(details);
 }
 
 const redisClient = (enableRedis === true) ? {


### PR DESCRIPTION
*(addresses #275)*

If the environment variable `REDIS_PASSWORD` is set to some string, it will be passed to the redis client as a password.