### PR TITLE
Only sync smartapi when NODE_ENV=production or SMARTAPI_SYNC overrides behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ You now can POST queries to `http://<HOST>:3000/v1/query`.
 
 Query Examples can be found [here](/examples).
 
+### Syncing SmartAPI Specifications
+
+By default, this package does not automatically sync the latest SmartAPI Specifications. You may set it to do so by setting either `NODE_ENV=production` or `SMARTAPI_SYNC=true` as environment variables (e.g. `SMARTAPI_SYNC=true npm start`). `SMARTAPI_SYNC` overrides the behavior of `NODE_ENV`.
+
+You may additionally manually trigger a one-time sync by using `npm run smartapi_sync` prior to running the project.
 
 ### Testing with Alternate SmartAPI Specs (local or hosted)
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "release:minor": "standard-version --release-as minor",
     "release:patch": "standard-version --release-as patch",
     "release:major": "standard-version --release-as major",
-    "siege-local": "artillery run -e local --output report_local.json --config performance-test/config.yaml performance-test/scenarios/query.yaml"
+    "siege-local": "artillery run -e local --output report_local.json --config performance-test/config.yaml performance-test/scenarios/query.yaml",
+    "smartapi_sync": "SYNC_AND_EXIT=true node ./scripts/smartapi_sync.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/smartapi_sync.js
+++ b/scripts/smartapi_sync.js
@@ -1,0 +1,2 @@
+sync = require("../src/controllers/cron/update_local_smartapi.js");
+sync();

--- a/src/controllers/cron/update_local_smartapi.js
+++ b/src/controllers/cron/update_local_smartapi.js
@@ -246,8 +246,24 @@ const getAPIOverrides = async (data) => {
 
 
 module.exports = () => {
-    let disable_smartapi_sync = process.env.DISABLE_SMARTAPI_SYNC === 'true';
+    let sync_and_exit = process.env.SYNC_AND_EXIT === 'true';
+
+    if (sync_and_exit) {
+        console.log("Syncing SmartAPI specs with subsequent exit...");
+        updateSmartAPISpecs().then(() => {
+            console.log("SmartAPI sync successful.");
+            process.exit(0);
+        });
+        return;
+    }
+
+    let schedule_sync = process.env.NODE_ENV === 'production';
+    let manual_sync = process.env.SMARTAPI_SYNC === 'true'
+        ? true : process.env.SMARTAPI_SYNC === 'false'
+            ? false
+            : undefined;
     let api_override = process.env.API_OVERRIDE === 'true';
+    disable_smartapi_sync = manual_sync || (schedule_sync && typeof manual_sync === "undefined");
     if (disable_smartapi_sync) {
         debug(`DISABLE_SMARTAPI_SYNC=true, server process ${process.pid} disabling smartapi updates.`);
     } else {

--- a/src/controllers/cron/update_local_smartapi.js
+++ b/src/controllers/cron/update_local_smartapi.js
@@ -246,8 +246,9 @@ const getAPIOverrides = async (data) => {
 
 
 module.exports = () => {
+    // not meant to be used with server started
+    // rather, if just this function is imported and run (e.g. using workspace script)
     let sync_and_exit = process.env.SYNC_AND_EXIT === 'true';
-
     if (sync_and_exit) {
         console.log("Syncing SmartAPI specs with subsequent exit...");
         updateSmartAPISpecs().then(() => {


### PR DESCRIPTION
*(addresses #271)*

By setting `NODE_ENV=production`, the server will schedule sync of the local smartapi, otherwise it will not by default. This behavior is overridden by setting `SMARTAPI_SYNC=true | false`, which will take precedence regardless of `NODE_ENV`. 

Also supported is `SYNC_AND_EXIT`, which will cause smartapi to be updated and then the process will exit. It is recommended that this is not used when launching the server, but instead by importing the default of `update_local_smartapi.js` and running it (PR for workspace script to do this incoming).