### PR TITLE
fixing 'LINCS Data Portal API' ID

### DIFF
--- a/src/routes/v1/config.js
+++ b/src/routes/v1/config.js
@@ -9,7 +9,7 @@ exports.API_LIST = [
         name: 'EBI Proteins API'
     },
     {
-        id: '1ad2cba40cb25cd70d00aa8fba9cfaf3',
+        id: '9ee398a738916a98b612068cc022454f',
         name: 'LINCS Data Portal API'
     },
     {


### PR DESCRIPTION
Based on https://smart-api.info/registry?q=lincs, I believe `9ee398a738916a98b612068cc022454f` is the correct ID to use because it is tagged with `Translator: KP` and because the [linked SmartAPI metadata](https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/master/LINCS/smartapi.yml) has `x-bte`.  In contrast, the [SmartAPI metadata](https://raw.githubusercontent.com/schurerlab/smartAPIs/master/LINCS_Data_Portal_smartAPIs.yml) for `1ad2cba40cb25cd70d00aa8fba9cfaf3` does not have `x-bte` information.