### PR TITLE
fix: :bug: update outdated handler option name, remove unused imports

### DIFF
--- a/src/routes/v1/asyncquery_v1.js
+++ b/src/routes/v1/asyncquery_v1.js
@@ -1,7 +1,4 @@
-const Queue = require('bull');
 const path = require("path");
-const axios = require('axios')
-const redisClient = require('../../utils/cache/redis-client');
 const config = require("./config");
 const TRAPIGraphHandler = require("@biothings-explorer/query_graph_handler");
 const swaggerValidation = require("../../middlewares/validate");
@@ -10,13 +7,12 @@ const predicatesPath = path.resolve(__dirname, '../../../data/predicates.json');
 const utils = require("../../utils/common");
 const {asyncquery, asyncqueryResponse} = require('../../controllers/asyncquery')
 const {getQueryQueue} = require('../../controllers/asyncquery_queue')
-const URL = require("url").URL;
 
 queryQueue = getQueryQueue('get query graph')
 
 async function jobToBeDone(queryGraph, caching, workflow, callback_url){
     utils.validateWorkflow(workflow);
-    const handler = new TRAPIGraphHandler.TRAPIQueryHandler({ apiNames: config.API_LIST, caching: caching }, smartAPIPath, predicatesPath);
+    const handler = new TRAPIGraphHandler.TRAPIQueryHandler({ apiList: config.API_LIST, caching: caching }, smartAPIPath, predicatesPath);
     handler.setQueryGraph(queryGraph);
     return await asyncqueryResponse(handler, callback_url);
 }

--- a/src/routes/v1/asyncquery_v1_by_api.js
+++ b/src/routes/v1/asyncquery_v1_by_api.js
@@ -1,9 +1,4 @@
-const Queue = require('bull');
 const path = require("path");
-const axios = require('axios');
-const { nanoid } = require('nanoid');
-const redisClient = require('../../utils/cache/redis-client');
-const config = require("./config");
 const TRAPIGraphHandler = require("@biothings-explorer/query_graph_handler");
 const swaggerValidation = require("../../middlewares/validate");
 const smartAPIPath = path.resolve(__dirname, '../../../data/smartapi_specs.json');

--- a/src/routes/v1/asyncquery_v1_by_team.js
+++ b/src/routes/v1/asyncquery_v1_by_team.js
@@ -1,9 +1,4 @@
-const Queue = require('bull');
 const path = require("path");
-const axios = require('axios')
-const { nanoid } = require('nanoid')
-const redisClient = require('../../utils/cache/redis-client');
-const config = require("./config");
 const TRAPIGraphHandler = require("@biothings-explorer/query_graph_handler");
 const swaggerValidation = require("../../middlewares/validate");
 const smartAPIPath = path.resolve(__dirname, '../../../data/smartapi_specs.json');

--- a/src/routes/v1/check_query_status.js
+++ b/src/routes/v1/check_query_status.js
@@ -1,4 +1,3 @@
-const Queue = require('bull');
 const redisClient = require('../../utils/cache/redis-client');
 const {getQueryQueue} = require('../../controllers/asyncquery_queue');
 


### PR DESCRIPTION
Async query endpoint filters out apis not in config passing the right option to the KG package.  This endpoint was using an outdated option name.
Cleanup* Remove unused imports in a few endpoints.