### PR TITLE
add Connections Hypothesis Provider API

### DIFF
--- a/src/routes/v1/config.js
+++ b/src/routes/v1/config.js
@@ -217,13 +217,11 @@ exports.API_LIST = [
         name: 'ICEES Asthma Instance API'
     },
     {
-        id: '65292eac9a88e3a895be21f19b554767',
-        name: 'ICEES COVID-19 Instance API'
-    },
-    {
         id: '9dd890397a7b8d98fbe247d56cac2b8f',
         name: 'ICEES DILI Instance API'
-    },
+    },    
+    // notes on ICEES:
+    // - don't ingest the COVID APIs (they may be broken / not actively developed)
     {
         id: '855adaa128ce5aa58a091d99e520d396',
         name: 'Connections Hypothesis Provider API'

--- a/src/routes/v1/config.js
+++ b/src/routes/v1/config.js
@@ -224,4 +224,8 @@ exports.API_LIST = [
         id: '9dd890397a7b8d98fbe247d56cac2b8f',
         name: 'ICEES DILI Instance API'
     },
+    {
+        id: '855adaa128ce5aa58a091d99e520d396',
+        name: 'Connections Hypothesis Provider API'
+    },
 ];


### PR DESCRIPTION
This PR adds Connections Hypothesis Provider to the default list of APIs that BTE queries.  This is necessary to provide answers for the standup query in https://github.com/NCATSTranslator/testing/issues/132.  Tested locally with that query and results from Connections Hypothesis Provider are being returned as expected.