### PR TITLE
feat: rate limit all sync endpoints

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -67,5 +67,11 @@ module.exports = class Config {
             max: process.env.MAX_QUERIES_PER_MIN || 15
         });
         this.app.use("/v1/query", limiter);
+        this.app.use("/v1/team/:team_name/query", limiter);
+        this.app.use("/v1/team/:team_name/query", limiter);
+        this.app.use("/test/query", limiter);
+        this.app.use("/v1/meta_knowledge_graph", limiter);
+        this.app.use("/v1/team/:teamName/meta_knowledge_graph", limiter);
+        this.app.use("/v1/smartapi/:smartapiID/meta_knowledge_graph", limiter);
     }
 }


### PR DESCRIPTION
Applies the 15 per-minute rate limit to sync endpoints:

```
/v1/team/:team_name/query
/v1/team/:team_name/query
/test/query
/v1/meta_knowledge_graph
/v1/team/:teamName/meta_knowledge_graph
/v1/smartapi/:smartapiID/meta_knowledge_graph
```