### PR TITLE
Process asyncquery jobs in child process, increase callback max. size to 2GB

### DIFF
--- a/src/controllers/async/asyncquery.js
+++ b/src/controllers/async/asyncquery.js
@@ -1,6 +1,6 @@
 const axios = require('axios')
 const { customAlphabet } = require('nanoid')
-const utils = require('../utils/common')
+const utils = require('../../utils/common')
 
 exports.asyncquery = async (req, res, next, queueData, queryQueue) => {
     try {
@@ -66,7 +66,8 @@ exports.asyncqueryResponse = async (handler, callback_url) => {
                 headers: {
                     'Content-Type': 'application/json'
                 },
-                timeout: 300000   // 5min
+                timeout: 300000,   // 5min
+                maxBodyLength: 2 * 1000 * 1000 * 1000 // 2GB
             });
             //console.log(res)
         }catch (e){

--- a/src/controllers/async/asyncquery_queue.js
+++ b/src/controllers/async/asyncquery_queue.js
@@ -1,5 +1,5 @@
 const Queue = require('bull');
-const redisClient = require('../utils/cache/redis-client');
+const redisClient = require('../../utils/cache/redis-client');
 
 exports.getQueryQueue = (name) => {
     let queryQueue = null;
@@ -26,4 +26,3 @@ exports.getQueryQueue = (name) => {
     }
     return queryQueue
 }
-

--- a/src/controllers/async/processors/async_v1.js
+++ b/src/controllers/async/processors/async_v1.js
@@ -1,0 +1,23 @@
+const path = require("path");
+const config = require("../../../routes/v1/config");
+const TRAPIGraphHandler = require("@biothings-explorer/query_graph_handler");
+const smartAPIPath = path.resolve(__dirname, "../../../../data/smartapi_specs.json");
+const predicatesPath = path.resolve(__dirname, "../../../../data/predicates.json");
+const utils = require("../../../utils/common");
+const { asyncqueryResponse } = require("../asyncquery");
+
+async function jobToBeDone(queryGraph, caching, workflow, callback_url) {
+    utils.validateWorkflow(workflow);
+    const handler = new TRAPIGraphHandler.TRAPIQueryHandler(
+        { apiList: config.API_LIST, caching: caching },
+        smartAPIPath,
+        predicatesPath,
+    );
+    handler.setQueryGraph(queryGraph);
+    const result = await asyncqueryResponse(handler, callback_url);
+    return result;
+}
+
+module.exports = async (job) => {
+    return await jobToBeDone(job.data.queryGraph, job.data.caching, job.data.workflow, job.data.callback_url);
+};

--- a/src/controllers/async/processors/async_v1_by_api.js
+++ b/src/controllers/async/processors/async_v1_by_api.js
@@ -1,0 +1,33 @@
+const path = require("path");
+const TRAPIGraphHandler = require("@biothings-explorer/query_graph_handler");
+const smartAPIPath = path.resolve(__dirname, '../../../../data/smartapi_specs.json');
+const predicatesPath = path.resolve(__dirname, '../../../../data/predicates.json');
+const { asyncqueryResponse } = require('../asyncquery');
+const utils = require("../../../utils/common");
+
+async function jobToBeDone(queryGraph, smartAPIID, caching, enableIDResolution, workflow, callback_url){
+    utils.validateWorkflow(workflow);
+    const handler = new TRAPIGraphHandler.TRAPIQueryHandler(
+        {
+            smartAPIID,
+            caching,
+            enableIDResolution
+        },
+        smartAPIPath,
+        predicatesPath,
+        false
+    );
+    handler.setQueryGraph(queryGraph);
+    return await asyncqueryResponse(handler, callback_url);
+}
+
+module.exports = async (job) => {
+    return await jobToBeDone(
+            job.data.queryGraph,
+            job.data.smartAPIID,
+            job.data.caching,
+            job.data.enableIDResolution,
+            job.data.workflow,
+            job.data.callback_url
+        );
+}

--- a/src/controllers/async/processors/async_v1_by_team.js
+++ b/src/controllers/async/processors/async_v1_by_team.js
@@ -1,0 +1,33 @@
+const path = require("path");
+const TRAPIGraphHandler = require("@biothings-explorer/query_graph_handler");
+const smartAPIPath = path.resolve(__dirname, '../../../../data/smartapi_specs.json');
+const predicatesPath = path.resolve(__dirname, '../../../../data/predicates.json');
+const { asyncqueryResponse } = require('../asyncquery');
+const utils = require("../../../utils/common");
+
+async function jobToBeDone(queryGraph, teamName, caching, enableIDResolution, workflow, callback_url){
+    utils.validateWorkflow(workflow);
+    const handler = new TRAPIGraphHandler.TRAPIQueryHandler(
+        {
+            teamName,
+            caching,
+            enableIDResolution
+        },
+        smartAPIPath,
+        predicatesPath,
+        false
+    );
+    handler.setQueryGraph(queryGraph);
+    return await asyncqueryResponse(handler, callback_url);
+}
+
+module.exports = async (job) => {
+    return await jobToBeDone(
+        job.data.queryGraph,
+        job.data.teamName,
+        job.data.caching,
+        job.data.enableIDResolution,
+        job.data.workflow,
+        job.data.callback_url,
+    );
+};

--- a/src/routes/v1/asyncquery_v1.js
+++ b/src/routes/v1/asyncquery_v1.js
@@ -1,26 +1,12 @@
 const path = require("path");
-const config = require("./config");
-const TRAPIGraphHandler = require("@biothings-explorer/query_graph_handler");
 const swaggerValidation = require("../../middlewares/validate");
-const smartAPIPath = path.resolve(__dirname, '../../../data/smartapi_specs.json');
-const predicatesPath = path.resolve(__dirname, '../../../data/predicates.json');
-const utils = require("../../utils/common");
-const {asyncquery, asyncqueryResponse} = require('../../controllers/asyncquery')
-const {getQueryQueue} = require('../../controllers/asyncquery_queue')
+const { asyncquery } = require('../../controllers/async/asyncquery')
+const { getQueryQueue } = require('../../controllers/async/asyncquery_queue')
 
 queryQueue = getQueryQueue('get query graph')
 
-async function jobToBeDone(queryGraph, caching, workflow, callback_url){
-    utils.validateWorkflow(workflow);
-    const handler = new TRAPIGraphHandler.TRAPIQueryHandler({ apiList: config.API_LIST, caching: caching }, smartAPIPath, predicatesPath);
-    handler.setQueryGraph(queryGraph);
-    return await asyncqueryResponse(handler, callback_url);
-}
-
-if(queryQueue){
-    queryQueue.process(async (job) => {
-        return await jobToBeDone(job.data.queryGraph, job.data.caching, job.data.workflow, job.data.callback_url);
-    });
+if (queryQueue) {
+    queryQueue.process(path.resolve(__dirname, "../../controllers/async/processors/async_v1.js"));
 }
 
 class V1RouteAsyncQuery {

--- a/src/routes/v1/asyncquery_v1_by_api.js
+++ b/src/routes/v1/asyncquery_v1_by_api.js
@@ -1,40 +1,12 @@
 const path = require("path");
-const TRAPIGraphHandler = require("@biothings-explorer/query_graph_handler");
 const swaggerValidation = require("../../middlewares/validate");
-const smartAPIPath = path.resolve(__dirname, '../../../data/smartapi_specs.json');
-const predicatesPath = path.resolve(__dirname, '../../../data/predicates.json');
-const utils = require("../../utils/common");
-const {asyncquery, asyncqueryResponse} = require('../../controllers/asyncquery');
-const {getQueryQueue} = require('../../controllers/asyncquery_queue');
+const { asyncquery } = require('../../controllers/async/asyncquery');
+const { getQueryQueue } = require('../../controllers/async/asyncquery_queue');
 
 queryQueue = getQueryQueue('get query graph by api')
 
-async function jobToBeDone(queryGraph, smartAPIID, caching, enableIDResolution, workflow, callback_url){
-    utils.validateWorkflow(workflow);
-    const handler = new TRAPIGraphHandler.TRAPIQueryHandler(
-        {
-            smartAPIID,
-            caching,
-            enableIDResolution
-        },
-        smartAPIPath,
-        predicatesPath,
-        false
-    );
-    handler.setQueryGraph(queryGraph);
-    return await asyncqueryResponse(handler, callback_url);
-}
-
-if(queryQueue){
-    queryQueue.process(async (job) => {
-        return await jobToBeDone(
-            job.data.queryGraph,
-            job.data.smartAPIID,
-            job.data.caching,
-            job.data.enableIDResolution,
-            job.data.workflow,
-            job.data.callback_url);
-    });
+if (queryQueue) {
+    queryQueue.process(path.resolve(__dirname, "../../controllers/async/processors/async_v1_by_api.js"));
 }
 
 class V1RouteAsyncQueryByAPI {

--- a/src/routes/v1/asyncquery_v1_by_team.js
+++ b/src/routes/v1/asyncquery_v1_by_team.js
@@ -1,40 +1,12 @@
 const path = require("path");
-const TRAPIGraphHandler = require("@biothings-explorer/query_graph_handler");
 const swaggerValidation = require("../../middlewares/validate");
-const smartAPIPath = path.resolve(__dirname, '../../../data/smartapi_specs.json');
-const predicatesPath = path.resolve(__dirname, '../../../data/predicates.json');
-const utils = require("../../utils/common");
-const {asyncquery, asyncqueryResponse} = require('../../controllers/asyncquery');
-const {getQueryQueue} = require('../../controllers/asyncquery_queue');
+const { asyncquery } = require('../../controllers/async/asyncquery');
+const { getQueryQueue } = require('../../controllers/async/asyncquery_queue');
 
 queryQueue = getQueryQueue('get query graph by team')
 
-async function jobToBeDone(queryGraph, teamName, caching, enableIDResolution, workflow, callback_url){
-    utils.validateWorkflow(workflow);
-    const handler = new TRAPIGraphHandler.TRAPIQueryHandler(
-        {
-            teamName,
-            caching,
-            enableIDResolution
-        },
-        smartAPIPath,
-        predicatesPath,
-        false
-    );
-    handler.setQueryGraph(queryGraph);
-    return await asyncqueryResponse(handler, callback_url);
-}
-
-if(queryQueue){
-    queryQueue.process(async (job) => {
-        return await jobToBeDone(
-            job.data.queryGraph,
-            job.data.teamName,
-            job.data.caching,
-            job.data.enableIDResolution,
-            job.data.workflow,
-            job.data.callback_url);
-    });
+if (queryQueue) {
+    queryQueue.process(path.resolve(__dirname, "../../controllers/async/processors/async_v1_by_team.js"));
 }
 
 class V1RouteAsyncQueryByTeam {

--- a/src/routes/v1/check_query_status.js
+++ b/src/routes/v1/check_query_status.js
@@ -1,5 +1,5 @@
 const redisClient = require('../../utils/cache/redis-client');
-const {getQueryQueue} = require('../../controllers/asyncquery_queue');
+const { getQueryQueue } = require('../../controllers/async/asyncquery_queue');
 
 let queryQueue;
 

--- a/src/routes/v1/config.js
+++ b/src/routes/v1/config.js
@@ -98,10 +98,10 @@ exports.API_LIST = [
     },
     // Text Mining Provider collab, annotated with x-bte
     // - removed Text Mining Co-occurrence API since there were issues using it with BTE (too many answers)
-    {
-        id: '978fe380a147a8641caf72320862697b',
-        name: 'Text Mining Targeted Association API'
-    },
+    // {
+    //     id: '978fe380a147a8641caf72320862697b',
+    //     name: 'Text Mining Targeted Association API'
+    // },
     // Automat APIs, ingested through TRAPI
     {
     // this API overlaps with our Biolink API registration, but we have bugs with our ingest...
@@ -161,7 +161,7 @@ exports.API_LIST = [
         id: '6c7642a4bf213769361c8f9ec1be88f2',
         name: 'Automat Hetio (trapi v-1.2.0)'
     },
-    {  
+    {
     // this API overlaps with our BioThings GO APIs, but
     //   may have been updated more recently / transformed data into TRAPI format
         id: '6118e4e713af49f48b37788593fd3fcb',
@@ -219,7 +219,7 @@ exports.API_LIST = [
     {
         id: '9dd890397a7b8d98fbe247d56cac2b8f',
         name: 'ICEES DILI Instance API'
-    },    
+    },
     // notes on ICEES:
     // - don't ingest the COVID APIs (they may be broken / not actively developed)
     {

--- a/src/routes/v1/config.js
+++ b/src/routes/v1/config.js
@@ -98,10 +98,10 @@ exports.API_LIST = [
     },
     // Text Mining Provider collab, annotated with x-bte
     // - removed Text Mining Co-occurrence API since there were issues using it with BTE (too many answers)
-    // {
-    //     id: '978fe380a147a8641caf72320862697b',
-    //     name: 'Text Mining Targeted Association API'
-    // },
+    {
+        id: '978fe380a147a8641caf72320862697b',
+        name: 'Text Mining Targeted Association API'
+    },
     // Automat APIs, ingested through TRAPI
     {
     // this API overlaps with our Biolink API registration, but we have bugs with our ingest...


### PR DESCRIPTION
*(Addresses #360)*
- Asyncquery jobs are processed in a child process using bull's built in [separate process handling](https://github.com/OptimalBits/bull#separate-processes). Code refactored accordingly.
- Async callback size maximum has been increased from default (2kb) to 2GB. We don't expect to handle significantly larger responses than this so it should do for now.

During testing, this appeared to fix Missing Lock errors that were noted in A.2, D.2, and D.6. One test showed D.3 now having a Missing Lock error, however this did not occur in every test. It's possible this is caused by a separate issue.