### PR TITLE
feat: jobID contains endpoint info, STATIC_PATH ENV variable

### DIFF
--- a/src/controllers/async/asyncquery.js
+++ b/src/controllers/async/asyncquery.js
@@ -7,19 +7,18 @@ exports.asyncquery = async (req, res, next, queueData, queryQueue) => {
         if(queryQueue){
             const nanoid = customAlphabet('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', 10)
 
-            const jobId = nanoid();
+            let jobId = nanoid();
 
             // add job to the queue
             let url
-            if(queryQueue.name==='get query graph'){
-                url = `${req.protocol}://${req.header('host')}/v1/check_query_status/${jobId}`
+            if(queryQueue.name==='bte_query_queue_by_api'){
+                jobId = `BA_${jobId}`
             }
-            if(queryQueue.name==='get query graph by api'){
-                url = `${req.protocol}://${req.header('host')}/v1/check_query_status/${jobId}?by=api`
+            if(queryQueue.name==='bte_query_queue_by_team'){
+                jobId = `BT_${jobId}`
             }
-            if(queryQueue.name==='get query graph by team'){
-                url = `${req.protocol}://${req.header('host')}/v1/check_query_status/${jobId}?by=team`
-            }
+            url = `${req.protocol}://${req.header('host')}/v1/check_query_status/${jobId}`
+
             let job = await queryQueue.add(
                 queueData,
                 {

--- a/src/controllers/async/processors/async_v1.js
+++ b/src/controllers/async/processors/async_v1.js
@@ -1,8 +1,8 @@
 const path = require("path");
 const config = require("../../../routes/v1/config");
 const TRAPIGraphHandler = require("@biothings-explorer/query_graph_handler");
-const smartAPIPath = path.resolve(__dirname, "../../../../data/smartapi_specs.json");
-const predicatesPath = path.resolve(__dirname, "../../../../data/predicates.json");
+const smartAPIPath = path.resolve(__dirname, process.env.STATIC_PATH ? `${process.env.STATIC_PATH}/data/smartapi_specs.json` : '../../../../data/smartapi_specs.json');
+const predicatesPath = path.resolve(__dirname, process.env.STATIC_PATH ? `${process.env.STATIC_PATH}/data/predicates.json` : '../../../../data/predicates.json');
 const utils = require("../../../utils/common");
 const { asyncqueryResponse } = require("../asyncquery");
 

--- a/src/controllers/async/processors/async_v1_by_api.js
+++ b/src/controllers/async/processors/async_v1_by_api.js
@@ -1,7 +1,7 @@
 const path = require("path");
 const TRAPIGraphHandler = require("@biothings-explorer/query_graph_handler");
-const smartAPIPath = path.resolve(__dirname, '../../../../data/smartapi_specs.json');
-const predicatesPath = path.resolve(__dirname, '../../../../data/predicates.json');
+const smartAPIPath = path.resolve(__dirname, process.env.STATIC_PATH ? `${process.env.STATIC_PATH}/data/smartapi_specs.json` : '../../../../data/smartapi_specs.json');
+const predicatesPath = path.resolve(__dirname, process.env.STATIC_PATH ? `${process.env.STATIC_PATH}/data/predicates.json` : '../../../../data/predicates.json');
 const { asyncqueryResponse } = require('../asyncquery');
 const utils = require("../../../utils/common");
 

--- a/src/controllers/async/processors/async_v1_by_team.js
+++ b/src/controllers/async/processors/async_v1_by_team.js
@@ -1,7 +1,7 @@
 const path = require("path");
 const TRAPIGraphHandler = require("@biothings-explorer/query_graph_handler");
-const smartAPIPath = path.resolve(__dirname, '../../../../data/smartapi_specs.json');
-const predicatesPath = path.resolve(__dirname, '../../../../data/predicates.json');
+const smartAPIPath = path.resolve(__dirname, process.env.STATIC_PATH ? `${process.env.STATIC_PATH}/data/smartapi_specs.json` : '../../../../data/smartapi_specs.json');
+const predicatesPath = path.resolve(__dirname, process.env.STATIC_PATH ? `${process.env.STATIC_PATH}/data/predicates.json` : '../../../../data/predicates.json');
 const { asyncqueryResponse } = require('../asyncquery');
 const utils = require("../../../utils/common");
 

--- a/src/routes/v1/asyncquery_v1.js
+++ b/src/routes/v1/asyncquery_v1.js
@@ -3,7 +3,7 @@ const swaggerValidation = require("../../middlewares/validate");
 const { asyncquery } = require('../../controllers/async/asyncquery')
 const { getQueryQueue } = require('../../controllers/async/asyncquery_queue')
 
-queryQueue = getQueryQueue('get query graph')
+queryQueue = getQueryQueue('bte_query_queue')
 
 if (queryQueue) {
     queryQueue.process(path.resolve(__dirname, "../../controllers/async/processors/async_v1.js"));
@@ -13,7 +13,7 @@ class V1RouteAsyncQuery {
     setRoutes(app) {
         app.post('/v1/asyncquery', swaggerValidation.validate, async (req, res, next) => {
             // if I don't reinitialize this then the wrong queue will be used, not sure why this happens
-            queryQueue = getQueryQueue('get query graph')
+            queryQueue = getQueryQueue('bte_query_queue')
 
             let queueData = {
                 queryGraph: req.body.message.query_graph,

--- a/src/routes/v1/asyncquery_v1_by_api.js
+++ b/src/routes/v1/asyncquery_v1_by_api.js
@@ -3,7 +3,7 @@ const swaggerValidation = require("../../middlewares/validate");
 const { asyncquery } = require('../../controllers/async/asyncquery');
 const { getQueryQueue } = require('../../controllers/async/asyncquery_queue');
 
-queryQueue = getQueryQueue('get query graph by api')
+queryQueue = getQueryQueue('bte_query_queue_by_api')
 
 if (queryQueue) {
     queryQueue.process(path.resolve(__dirname, "../../controllers/async/processors/async_v1_by_api.js"));
@@ -12,7 +12,7 @@ if (queryQueue) {
 class V1RouteAsyncQueryByAPI {
     setRoutes(app) {
         app.post('/v1/smartapi/:smartapi_id/asyncquery', swaggerValidation.validate, async (req, res, next) => {
-            queryQueue = getQueryQueue('get query graph by api')
+            queryQueue = getQueryQueue('bte_query_queue_by_api')
 
             const enableIDResolution = (['5be0f321a829792e934545998b9c6afe', '978fe380a147a8641caf72320862697b'].includes(req.params.smartapi_id)) ? false : true;
             let queueData = {

--- a/src/routes/v1/asyncquery_v1_by_team.js
+++ b/src/routes/v1/asyncquery_v1_by_team.js
@@ -3,7 +3,7 @@ const swaggerValidation = require("../../middlewares/validate");
 const { asyncquery } = require('../../controllers/async/asyncquery');
 const { getQueryQueue } = require('../../controllers/async/asyncquery_queue');
 
-queryQueue = getQueryQueue('get query graph by team')
+queryQueue = getQueryQueue('bte_query_queue_by_team')
 
 if (queryQueue) {
     queryQueue.process(path.resolve(__dirname, "../../controllers/async/processors/async_v1_by_team.js"));
@@ -12,7 +12,7 @@ if (queryQueue) {
 class V1RouteAsyncQueryByTeam {
     setRoutes(app) {
         app.post('/v1/team/:team_name/asyncquery', swaggerValidation.validate, async (req, res, next) => {
-            queryQueue = getQueryQueue('get query graph by team')
+            queryQueue = getQueryQueue('bte_query_queue_by_team')
             const queryGraph = req.body.message.query_graph;
             const enableIDResolution = (req.params.team_name === "Text Mining Provider") ? false : true;
             let queueData = {

--- a/src/routes/v1/check_query_status.js
+++ b/src/routes/v1/check_query_status.js
@@ -1,5 +1,6 @@
+const Queue = require('bull');
 const redisClient = require('../../utils/cache/redis-client');
-const { getQueryQueue } = require('../../controllers/async/asyncquery_queue');
+const {getQueryQueue} = require('../../controllers/async/asyncquery_queue');
 
 let queryQueue;
 
@@ -10,16 +11,14 @@ class VCheckQueryStatus {
         app.get('/v1/check_query_status/:id', swaggerValidation.validate, async (req, res, next) => {
             //logger.info("query /query endpoint")
             try {
-                let by = req.query.by;
+                let id = req.params.id;
                 if(Object.keys(redisClient).length !== 0){
-                    if(!by){
-                        queryQueue = getQueryQueue('get query graph')
-                    }
-                    if(by==='api'){
-                        queryQueue = getQueryQueue('get query graph by api')
-                    }
-                    if(by==='team'){
-                        queryQueue = getQueryQueue('get query graph by team')
+                    if(id.startsWith('BT_')){
+                        queryQueue = getQueryQueue('bte_query_queue_by_team')
+                    } else if(id.startsWith('BA_')){
+                        queryQueue = getQueryQueue('bte_query_queue_by_api')
+                    }else{
+                        queryQueue = getQueryQueue('bte_query_queue')
                     }
                 }
                 if(queryQueue){

--- a/src/routes/v1/query_v1.js
+++ b/src/routes/v1/query_v1.js
@@ -2,8 +2,8 @@ const path = require("path");
 const config = require("./config");
 const TRAPIGraphHandler = require("@biothings-explorer/query_graph_handler");
 const swaggerValidation = require("../../middlewares/validate");
-const smartAPIPath = path.resolve(__dirname, '../../../data/smartapi_specs.json');
-const predicatesPath = path.resolve(__dirname, '../../../data/predicates.json');
+const smartAPIPath = path.resolve(__dirname, process.env.STATIC_PATH ? `${process.env.STATIC_PATH}/data/smartapi_specs.json` : '../../../data/smartapi_specs.json');
+const predicatesPath = path.resolve(__dirname, process.env.STATIC_PATH ? `${process.env.STATIC_PATH}/data/predicates.json` : '../../../data/predicates.json');
 const utils = require("../../utils/common");
 const { runTask, taskResponse, taskError } = require("../../controllers/threading/threadHandler");
 

--- a/src/routes/v1/query_v1_by_api.js
+++ b/src/routes/v1/query_v1_by_api.js
@@ -1,8 +1,8 @@
 const TRAPIGraphHandler = require("@biothings-explorer/query_graph_handler");
 const swaggerValidation = require("../../middlewares/validate")
 const path = require("path");
-const smartAPIPath = path.resolve(__dirname, '../../../data/smartapi_specs.json');
-const predicatesPath = path.resolve(__dirname, '../../../data/predicates.json');
+const smartAPIPath = path.resolve(__dirname, process.env.STATIC_PATH ? `${process.env.STATIC_PATH}/data/smartapi_specs.json` : '../../../data/smartapi_specs.json');
+const predicatesPath = path.resolve(__dirname, process.env.STATIC_PATH ? `${process.env.STATIC_PATH}/data/predicates.json` : '../../../data/predicates.json');
 const utils = require("../../utils/common");
 const { runTask, taskResponse, taskError } = require("../../controllers/threading/threadHandler");
 

--- a/src/routes/v1/query_v1_by_team.js
+++ b/src/routes/v1/query_v1_by_team.js
@@ -1,8 +1,8 @@
 const TRAPIGraphHandler = require("@biothings-explorer/query_graph_handler");
 const swaggerValidation = require("../../middlewares/validate")
 const path = require("path");
-const smartAPIPath = path.resolve(__dirname, '../../../data/smartapi_specs.json');
-const predicatesPath = path.resolve(__dirname, '../../../data/predicates.json');
+const smartAPIPath = path.resolve(__dirname, process.env.STATIC_PATH ? `${process.env.STATIC_PATH}/data/smartapi_specs.json` : '../../../data/smartapi_specs.json');
+const predicatesPath = path.resolve(__dirname, process.env.STATIC_PATH ? `${process.env.STATIC_PATH}/data/predicates.json` : '../../../data/predicates.json');
 const utils = require("../../utils/common");
 const { runTask, taskResponse, taskError } = require("../../controllers/threading/threadHandler");
 


### PR DESCRIPTION
Integrates @sengineer0's changes from [newgene/BioThings_Explorer_TRAPI](https://github.com/newgene/BioThings_Explorer_TRAPI) to the updated async file structure.

- jobIDs now include endpoint info instead of requiring a query param for `/v1/check_query_status` (fixes #365)
- Query queues renamed to be more accurate
- Implements ENV variable STATIC_PATH to provide a directory containing `/data/smartapi_specs.json` and `/data/predicates.json`