### PR TITLE
Additional debug information for async/generic errors

### DIFF
--- a/src/controllers/async/processors/async_v1.js
+++ b/src/controllers/async/processors/async_v1.js
@@ -6,7 +6,7 @@ const predicatesPath = path.resolve(__dirname, "../../../../data/predicates.json
 const utils = require("../../../utils/common");
 const { asyncqueryResponse } = require("../asyncquery");
 
-async function jobToBeDone(queryGraph, caching, workflow, callback_url) {
+async function jobToBeDone(jobURL, queryGraph, caching, workflow, callback_url) {
     utils.validateWorkflow(workflow);
     const handler = new TRAPIGraphHandler.TRAPIQueryHandler(
         { apiList: config.API_LIST, caching: caching },
@@ -14,10 +14,10 @@ async function jobToBeDone(queryGraph, caching, workflow, callback_url) {
         predicatesPath,
     );
     handler.setQueryGraph(queryGraph);
-    const result = await asyncqueryResponse(handler, callback_url);
+    const result = await asyncqueryResponse(handler, callback_url, jobURL);
     return result;
 }
 
 module.exports = async (job) => {
-    return await jobToBeDone(job.data.queryGraph, job.data.caching, job.data.workflow, job.data.callback_url);
+    return await jobToBeDone(job.data.url, job.data.queryGraph, job.data.caching, job.data.workflow, job.data.callback_url);
 };

--- a/src/controllers/async/processors/async_v1_by_api.js
+++ b/src/controllers/async/processors/async_v1_by_api.js
@@ -5,7 +5,7 @@ const predicatesPath = path.resolve(__dirname, '../../../../data/predicates.json
 const { asyncqueryResponse } = require('../asyncquery');
 const utils = require("../../../utils/common");
 
-async function jobToBeDone(queryGraph, smartAPIID, caching, enableIDResolution, workflow, callback_url){
+async function jobToBeDone(jobURL, queryGraph, smartAPIID, caching, enableIDResolution, workflow, callback_url){
     utils.validateWorkflow(workflow);
     const handler = new TRAPIGraphHandler.TRAPIQueryHandler(
         {
@@ -18,11 +18,12 @@ async function jobToBeDone(queryGraph, smartAPIID, caching, enableIDResolution, 
         false
     );
     handler.setQueryGraph(queryGraph);
-    return await asyncqueryResponse(handler, callback_url);
+    return await asyncqueryResponse(handler, callback_url, jobURL);
 }
 
 module.exports = async (job) => {
     return await jobToBeDone(
+            job.data.url,
             job.data.queryGraph,
             job.data.smartAPIID,
             job.data.caching,

--- a/src/controllers/async/processors/async_v1_by_team.js
+++ b/src/controllers/async/processors/async_v1_by_team.js
@@ -5,7 +5,7 @@ const predicatesPath = path.resolve(__dirname, '../../../../data/predicates.json
 const { asyncqueryResponse } = require('../asyncquery');
 const utils = require("../../../utils/common");
 
-async function jobToBeDone(queryGraph, teamName, caching, enableIDResolution, workflow, callback_url){
+async function jobToBeDone(jobURL, queryGraph, teamName, caching, enableIDResolution, workflow, callback_url){
     utils.validateWorkflow(workflow);
     const handler = new TRAPIGraphHandler.TRAPIQueryHandler(
         {
@@ -18,11 +18,12 @@ async function jobToBeDone(queryGraph, teamName, caching, enableIDResolution, wo
         false
     );
     handler.setQueryGraph(queryGraph);
-    return await asyncqueryResponse(handler, callback_url);
+    return await asyncqueryResponse(handler, callback_url, jobURL);
 }
 
 module.exports = async (job) => {
     return await jobToBeDone(
+        job.data.url,
         job.data.queryGraph,
         job.data.teamName,
         job.data.caching,

--- a/src/middlewares/error.js
+++ b/src/middlewares/error.js
@@ -45,10 +45,11 @@ class ErrorHandler {
                     message: {
                         query_graph: req.body.message.query_graph,
                         knowledge_graph: { nodes: {}, edges: {} },
-                        results: []    
+                        results: []
                     },
                     status: error.statusCode,
-                    description: error.toString() 
+                    description: error.toString(),
+                    trace: process.env.NODE_ENV === 'production' ? undefined : error.stack
                 });
         });
     }


### PR DESCRIPTION
This PR adds the job status URL for an async query as the first log entry in the response logs for debugging purposes. Additionally, if the server is not in production mode (e.g. local development), error stack traces are added to errors returned.