### PR TITLE
Fix #363: add max_results_by_edge query param

### DIFF
--- a/docs/smartapi.yaml
+++ b/docs/smartapi.yaml
@@ -112,6 +112,12 @@ paths:
           required: false
           schema:
             type: boolean
+        - description: maximum number of results to get back from querying each edge to limit exploding queries (-1 for uncapped)
+          in: query
+          name: max_results_per_edge
+          required: false
+          schema:
+            type: integer
       requestBody:
         description: Query information to be submitted
         required: true
@@ -172,6 +178,12 @@ paths:
           required: false
           schema:
             type: boolean
+        - description: maximum number of results to get back from querying each edge to limit exploding queries (-1 for uncapped)
+          in: query
+          name: max_results_per_edge
+          required: false
+          schema:
+            type: integer
       requestBody:
         description: Query information to be submitted
         required: true
@@ -239,6 +251,12 @@ paths:
           required: false
           schema:
             type: boolean
+        - description: maximum number of results to get back from querying each edge to limit exploding queries (-1 for uncapped)
+          in: query
+          name: max_results_per_edge
+          required: false
+          schema:
+            type: integer
       requestBody:
         description: Query information to be submitted
         required: true
@@ -345,6 +363,12 @@ paths:
           required: false
           schema:
             type: boolean
+        - description: maximum number of results to get back from querying each edge to limit exploding queries (-1 for uncapped)
+          in: query
+          name: max_results_per_edge
+          required: false
+          schema:
+            type: integer
       requestBody:
         description: Query information to be submitted
         required: true
@@ -416,6 +440,12 @@ paths:
           required: false
           schema:
             type: boolean
+        - description: maximum number of results to get back from querying each edge to limit exploding queries (-1 for uncapped)
+          in: query
+          name: max_results_per_edge
+          required: false
+          schema:
+            type: integer
       requestBody:
         description: Query information to be submitted
         required: true
@@ -492,6 +522,12 @@ paths:
           required: false
           schema:
             type: boolean
+        - description: maximum number of results to get back from querying each edge to limit exploding queries (-1 for uncapped)
+          in: query
+          name: max_results_per_edge
+          required: false
+          schema:
+            type: integer
       requestBody:
         description: Query information to be submitted
         required: true

--- a/docs/smartapi.yaml
+++ b/docs/smartapi.yaml
@@ -112,7 +112,7 @@ paths:
           required: false
           schema:
             type: boolean
-        - description: maximum number of results to get back from querying each edge to limit exploding queries (-1 for uncapped)
+        - description: maximum number of records to get back from querying each edge to limit exploding queries (turned off by default)
           in: query
           name: max_results_per_edge
           required: false
@@ -178,7 +178,7 @@ paths:
           required: false
           schema:
             type: boolean
-        - description: maximum number of results to get back from querying each edge to limit exploding queries (-1 for uncapped)
+        - description: maximum number of records to get back from querying each edge to limit exploding queries (turned off by default)
           in: query
           name: max_results_per_edge
           required: false
@@ -251,7 +251,7 @@ paths:
           required: false
           schema:
             type: boolean
-        - description: maximum number of results to get back from querying each edge to limit exploding queries (-1 for uncapped)
+        - description: maximum number of records to get back from querying each edge to limit exploding queries (turned off by default)
           in: query
           name: max_results_per_edge
           required: false
@@ -363,7 +363,7 @@ paths:
           required: false
           schema:
             type: boolean
-        - description: maximum number of results to get back from querying each edge to limit exploding queries (-1 for uncapped)
+        - description: maximum number of records to get back from querying each edge to limit exploding queries (turned off by default)
           in: query
           name: max_results_per_edge
           required: false
@@ -440,7 +440,7 @@ paths:
           required: false
           schema:
             type: boolean
-        - description: maximum number of results to get back from querying each edge to limit exploding queries (-1 for uncapped)
+        - description: maximum number of records to get back from querying each edge to limit exploding queries (turned off by default)
           in: query
           name: max_results_per_edge
           required: false
@@ -522,7 +522,7 @@ paths:
           required: false
           schema:
             type: boolean
-        - description: maximum number of results to get back from querying each edge to limit exploding queries (-1 for uncapped)
+        - description: maximum number of records to get back from querying each edge to limit exploding queries (turned off by default)
           in: query
           name: max_results_per_edge
           required: false

--- a/src/routes/v1/asyncquery_v1.js
+++ b/src/routes/v1/asyncquery_v1.js
@@ -19,7 +19,8 @@ class V1RouteAsyncQuery {
                 queryGraph: req.body.message.query_graph,
                 workflow: req.body.workflow,
                 callback_url: req.body.callback_url || req.body['callback'],
-                caching: req.query.caching
+                caching: req.query.caching,
+                maxResultsPerEdge: req.query.max_results_per_edge 
             }
             await asyncquery(req, res, next, queueData, queryQueue)
         });

--- a/src/routes/v1/asyncquery_v1_by_api.js
+++ b/src/routes/v1/asyncquery_v1_by_api.js
@@ -21,6 +21,7 @@ class V1RouteAsyncQueryByAPI {
                 caching: req.query.caching,
                 workflow: req.body.workflow,
                 callback_url: req.body.callback_url || req.body['callback'],
+                maxResultsPerEdge: req.query.max_results_per_edge,
                 enableIDResolution
             }
             await asyncquery(req, res, next, queueData, queryQueue)

--- a/src/routes/v1/asyncquery_v1_by_team.js
+++ b/src/routes/v1/asyncquery_v1_by_team.js
@@ -21,6 +21,7 @@ class V1RouteAsyncQueryByTeam {
                 caching: req.query.caching,
                 workflow: req.body.workflow,
                 callback_url: req.body.callback_url || req.body['callback'],
+                maxResultsPerEdge: req.query.max_results_per_edge,
                 enableIDResolution
             }
             await asyncquery(req, res, next, queueData, queryQueue)

--- a/src/routes/v1/query_v1.js
+++ b/src/routes/v1/query_v1.js
@@ -26,7 +26,11 @@ class V1RouteQuery {
             utils.validateWorkflow(req.body.workflow);
             const queryGraph = req.body.message.query_graph;
             const handler = new TRAPIGraphHandler.TRAPIQueryHandler(
-                { apiList: config.API_LIST, caching: req.query.caching },
+                { 
+                    apiList: config.API_LIST, 
+                    caching: req.query.caching, 
+                    maxResultsPerEdge: req.query.max_results_per_edge 
+                },
                 smartAPIPath,
                 predicatesPath,
             );

--- a/src/routes/v1/query_v1_by_api.js
+++ b/src/routes/v1/query_v1_by_api.js
@@ -28,6 +28,7 @@ class RouteQueryV1ByAPI {
                 {
                     smartAPIID: req.params.smartapi_id,
                     caching: req.query.caching,
+                    maxResultsPerEdge: req.query.max_results_per_edge, 
                     enableIDResolution
                 },
                 smartAPIPath,

--- a/src/routes/v1/query_v1_by_team.js
+++ b/src/routes/v1/query_v1_by_team.js
@@ -28,6 +28,7 @@ class RouteQueryV1ByTeam {
                 {
                     teamName: req.params.team_name,
                     caching: req.query.caching,
+                    maxResultsPerEdge: req.query.max_results_per_edge,
                     enableIDResolution
                 },
                 smartAPIPath,


### PR DESCRIPTION
Fixes #363.
Also merge: https://github.com/biothings/call-apis.js/pull/36 and https://github.com/biothings/bte_trapi_query_graph_handler/pull/82

Added `max_results_by_edge` query parameter to all `v1` endpoints. ~~It defaults to `1000` and can be set to `-1` to disable the results limiting behavior.~~ By default, it is turned off.

How the limiting works: In call-apis, after each query bucket, it checks the results array to see if the number of results has exceeded the maxResultsPerEdge. If it has, stop further querying and truncate the results array down to that number. These results are before filtering/intersecting.