### PR TITLE
Various async/threading fixes

### DIFF
--- a/src/controllers/async/asyncquery.js
+++ b/src/controllers/async/asyncquery.js
@@ -110,7 +110,7 @@ exports.getQueryResponse = async jobID => {
     }
 };
 
-exports.asyncqueryResponse = async (handler, callback_url, jobID = null, jobURL = null) => {
+exports.asyncqueryResponse = async (handler, callback_url, jobID = null, jobURL = null, queryGraph = null) => {
     let response;
     let callback_response;
     try {
@@ -126,9 +126,14 @@ exports.asyncqueryResponse = async (handler, callback_url, jobID = null, jobURL 
         console.error(e)
         //shape error > will be handled below
         response = {
-            error: e?.name,
-            message: e?.message,
-            trace: process.env.NODE_ENV === 'production' ? undefined : e?.stack
+                message: {
+                    query_graph: queryGraph,
+                    knowledge_graph: { nodes: {}, edges: {} },
+                    results: []
+                },
+                status: 500,
+                description: e.toString(),
+                trace: process.env.NODE_ENV === 'production' ? undefined : e.stack
         };
         if (jobID) {
             await storeQueryResponse(jobID, response);

--- a/src/controllers/async/processors/async_v1.js
+++ b/src/controllers/async/processors/async_v1.js
@@ -14,7 +14,7 @@ async function jobToBeDone(jobID, queryGraph, caching, workflow, callback_url, j
         predicatesPath,
     );
     handler.setQueryGraph(queryGraph);
-    const result = await asyncqueryResponse(handler, callback_url, jobID, jobURL);
+    const result = await asyncqueryResponse(handler, callback_url, jobID, jobURL, queryGraph);
     return result;
 }
 

--- a/src/controllers/async/processors/async_v1_by_api.js
+++ b/src/controllers/async/processors/async_v1_by_api.js
@@ -18,7 +18,7 @@ async function jobToBeDone(jobID, queryGraph, smartAPIID, caching, enableIDResol
         false
     );
     handler.setQueryGraph(queryGraph);
-    return await asyncqueryResponse(handler, callback_url, jobID, jobURL);
+    return await asyncqueryResponse(handler, callback_url, jobID, jobURL, queryGraph);
 }
 
 module.exports = async (job) => {

--- a/src/controllers/async/processors/async_v1_by_team.js
+++ b/src/controllers/async/processors/async_v1_by_team.js
@@ -18,7 +18,7 @@ async function jobToBeDone(jobID, queryGraph, teamName, caching, enableIDResolut
         false
     );
     handler.setQueryGraph(queryGraph);
-    return await asyncqueryResponse(handler, callback_url, jobID, jobURL);
+    return await asyncqueryResponse(handler, callback_url, jobID, jobURL, queryGraph);
 }
 
 module.exports = async (job) => {

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -44,11 +44,11 @@ module.exports = {
         query_v1_by_api: routesV1QueryByAPI.task,
         query_v1_by_team: routesV1QueryByTeam.task,
         query_test: routesQueryTest.task,
-        asyncquery_v1: routesV1AsyncQuery.task, //TODO
-        asyncquery_v1_by_api: routesV1AsyncQueryByAPI.task, //TODO
-        asyncquery_v1_by_team: routesV1AsyncQueryByTeam.task, //TODO
-        check_query_status: routesV1CheckQueryStatus.task, //TODO
+        check_query_status: routesV1CheckQueryStatus.task,
         // Not threaded due to being lightweight/speed being higher priority
+        asyncquery_v1: routesV1AsyncQuery.task,
+        asyncquery_v1_by_api: routesV1AsyncQueryByAPI.task,
+        asyncquery_v1_by_team: routesV1AsyncQueryByTeam.task,
         performance: routesPerformance.task,
         metakg: routesMetaKG.task,
         meta_knowledge_graph_v1: routesV1MetaKG.task,

--- a/src/routes/v1/check_query_status.js
+++ b/src/routes/v1/check_query_status.js
@@ -8,6 +8,7 @@ let queryQueue;
 
 const swaggerValidation = require("../../middlewares/validate");
 const { runTask, taskResponse, taskError } = require("../../controllers/threading/threadHandler");
+const debug = require('debug')('bte:biothings-explorer-trapi:async');
 
 class VCheckQueryStatus {
     setRoutes(app) {
@@ -25,6 +26,7 @@ class VCheckQueryStatus {
     async task(req) {
         //logger.info("query /query endpoint")
         try {
+            debug(`checking query status of job ${req.params.id}`);
             let by = req.query.by;
             let id = req.params.id;
             let queryQueue;


### PR DESCRIPTION
This PR implements a few changes:

- New `check_query_status` threads log to console that they are doing as such so threads don't appear to be doing nothing.
- Caught async errors now have a more TRAPI-compliant response.
- Some comments are changed for clarity regarding threading.