### PR TITLE
Support log_level

### DIFF
--- a/docs/smartapi.yaml
+++ b/docs/smartapi.yaml
@@ -297,6 +297,18 @@ paths:
           required: true
           schema:
             type: string
+        - description: option to override original query log level
+          in: query
+          name: log_level
+          required: false
+          schema:
+            type: string
+            description: Logging level
+            enum:
+              - ERROR
+              - WARNING
+              - INFO
+              - DEBUG
       responses:
         '200':
           description: Returns status. If successfully completed, it will return a TRAPI Response object

--- a/src/controllers/async/processors/async_v1.js
+++ b/src/controllers/async/processors/async_v1.js
@@ -6,10 +6,10 @@ const predicatesPath = path.resolve(__dirname, process.env.STATIC_PATH ? `${proc
 const utils = require("../../../utils/common");
 const { asyncqueryResponse } = require("../asyncquery");
 
-async function jobToBeDone(jobID, queryGraph, caching, workflow, callback_url, jobURL = null) {
+async function jobToBeDone(jobID, queryGraph, caching, workflow, callback_url, jobURL = null, logLevel = null) {
     utils.validateWorkflow(workflow);
     const handler = new TRAPIGraphHandler.TRAPIQueryHandler(
-        { apiList: config.API_LIST, caching: caching },
+        { apiList: config.API_LIST, caching: caching, logLevel: logLevel },
         smartAPIPath,
         predicatesPath,
     );
@@ -26,5 +26,6 @@ module.exports = async job => {
     job.data.workflow,
     job.data.callback_url,
     job.data.url,
+    job.data.logLevel,
   );
 };

--- a/src/controllers/async/processors/async_v1_by_api.js
+++ b/src/controllers/async/processors/async_v1_by_api.js
@@ -5,12 +5,13 @@ const predicatesPath = path.resolve(__dirname, process.env.STATIC_PATH ? `${proc
 const { asyncqueryResponse } = require('../asyncquery');
 const utils = require("../../../utils/common");
 
-async function jobToBeDone(jobID, queryGraph, smartAPIID, caching, enableIDResolution, workflow, callback_url, jobURL = null){
+async function jobToBeDone(jobID, queryGraph, smartAPIID, caching, enableIDResolution, workflow, callback_url, jobURL = null, logLevel = null){
     utils.validateWorkflow(workflow);
     const handler = new TRAPIGraphHandler.TRAPIQueryHandler(
         {
             smartAPIID,
             caching,
+            logLevel,
             enableIDResolution
         },
         smartAPIPath,
@@ -23,13 +24,14 @@ async function jobToBeDone(jobID, queryGraph, smartAPIID, caching, enableIDResol
 
 module.exports = async (job) => {
     return await jobToBeDone(
-            job.data.id,
-            job.data.queryGraph,
-            job.data.smartAPIID,
-            job.data.caching,
-            job.data.enableIDResolution,
-            job.data.workflow,
-            job.data.callback_url,
-            job.data.url,
-        );
+        job.data.id,
+        job.data.queryGraph,
+        job.data.smartAPIID,
+        job.data.caching,
+        job.data.enableIDResolution,
+        job.data.workflow,
+        job.data.callback_url,
+        job.data.url,
+        job.data.logLevel,
+    );
 }

--- a/src/controllers/async/processors/async_v1_by_team.js
+++ b/src/controllers/async/processors/async_v1_by_team.js
@@ -5,12 +5,13 @@ const predicatesPath = path.resolve(__dirname, process.env.STATIC_PATH ? `${proc
 const { asyncqueryResponse } = require('../asyncquery');
 const utils = require("../../../utils/common");
 
-async function jobToBeDone(jobID, queryGraph, teamName, caching, enableIDResolution, workflow, callback_url, jobURL = null){
+async function jobToBeDone(jobID, queryGraph, teamName, caching, enableIDResolution, workflow, callback_url, jobURL = null, logLevel = null){
     utils.validateWorkflow(workflow);
     const handler = new TRAPIGraphHandler.TRAPIQueryHandler(
         {
             teamName,
             caching,
+            logLevel,
             enableIDResolution
         },
         smartAPIPath,
@@ -31,5 +32,6 @@ module.exports = async (job) => {
         job.data.workflow,
         job.data.callback_url,
         job.data.url,
+        job.data.logLevel,
     );
 };

--- a/src/routes/v1/asyncquery_v1.js
+++ b/src/routes/v1/asyncquery_v1.js
@@ -19,7 +19,8 @@ class V1RouteAsyncQuery {
                 queryGraph: req.body.message.query_graph,
                 workflow: req.body.workflow,
                 callback_url: req.body.callback_url || req.body['callback'],
-                caching: req.query.caching
+                caching: req.query.caching,
+                logLevel: req.body.log_level,
             }
             await asyncquery(req, res, next, queueData, queryQueue)
         });

--- a/src/routes/v1/asyncquery_v1_by_api.js
+++ b/src/routes/v1/asyncquery_v1_by_api.js
@@ -19,6 +19,7 @@ class V1RouteAsyncQueryByAPI {
                 queryGraph: req.body.message.query_graph,
                 smartAPIID: req.params.smartapi_id,
                 caching: req.query.caching,
+                logLevel: req.body.log_level,
                 workflow: req.body.workflow,
                 callback_url: req.body.callback_url || req.body['callback'],
                 enableIDResolution

--- a/src/routes/v1/asyncquery_v1_by_team.js
+++ b/src/routes/v1/asyncquery_v1_by_team.js
@@ -19,6 +19,7 @@ class V1RouteAsyncQueryByTeam {
                 queryGraph: queryGraph,
                 teamName: req.params.team_name,
                 caching: req.query.caching,
+                logLevel: req.body.log_level,
                 workflow: req.body.workflow,
                 callback_url: req.body.callback_url || req.body['callback'],
                 enableIDResolution

--- a/src/routes/v1/check_query_status.js
+++ b/src/routes/v1/check_query_status.js
@@ -3,6 +3,7 @@ const redisClient = require('../../utils/cache/redis-client');
 const { getQueryQueue } = require('../../controllers/async/asyncquery_queue');
 const { getQueryResponse } = require('../../controllers/async/asyncquery');
 const lz4 = require('lz4');
+const utils = require('../../utils/common');
 
 let queryQueue;
 
@@ -67,7 +68,7 @@ class VCheckQueryStatus {
                     }
                     let returnvalue = job.returnvalue;
                     if (returnvalue?.response && !returnvalue?.response?.error) {
-                        const storedResponse = await getQueryResponse(id);
+                        const storedResponse = await getQueryResponse(id, req.query.log_level);
                         if (storedResponse) {
                             returnvalue.response = storedResponse;
                         } else {

--- a/src/routes/v1/query_v1.js
+++ b/src/routes/v1/query_v1.js
@@ -33,7 +33,9 @@ class V1RouteQuery {
             handler.setQueryGraph(queryGraph);
             await handler.query();
 
-            return taskResponse(handler.getResponse());
+            const response = handler.getResponse();
+            utils.filterForLogLevel(response, req.body.log_level);
+            return taskResponse(response);
         } catch (error) {
             return taskError(error);
         }

--- a/src/routes/v1/query_v1_by_api.js
+++ b/src/routes/v1/query_v1_by_api.js
@@ -36,7 +36,9 @@ class RouteQueryV1ByAPI {
             );
             handler.setQueryGraph(queryGraph);
             await handler.query();
-            return taskResponse(handler.getResponse());
+            const response = handler.getResponse();
+            utils.filterForLogLevel(response, req.body.log_level);
+            return taskResponse(response);
         } catch (error) {
             return taskError(error);
         }

--- a/src/routes/v1/query_v1_by_team.js
+++ b/src/routes/v1/query_v1_by_team.js
@@ -36,7 +36,9 @@ class RouteQueryV1ByTeam {
             );
             handler.setQueryGraph(queryGraph);
             await handler.query();
-            taskResponse(handler.getResponse());
+            const response = handler.getResponse();
+            utils.filterForLogLevel(response, req.body.log_level);
+            taskResponse(response);
         } catch (error) {
             taskError(error);
         }

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -28,3 +28,17 @@ exports.stringIsAValidUrl = (s) => {
         return false;
     }
 };
+
+exports.filterForLogLevel = (response, logLevel) => {
+    const logLevels = {
+        ERROR: 3,
+        WARNING: 2,
+        INFO: 1,
+        DEBUG: 0
+    }
+    if (logLevel && Object.keys(logLevels).includes(logLevel)) {
+        response.logs = response.logs.filter(log => {
+            return logLevels[log.level] >= logLevels[logLevel]
+        });
+    }
+}


### PR DESCRIPTION
First pass addressing biothings/BioThings_Explorer_TRAPI#328. Part of 4 related PRs:

- biothings/BioThings_Explorer_TRAPI/pull/393
- biothings/call-apis.js/pull/38
- biothings/bte_trapi_query_graph_handler/pull/85
- biothings/smartapi-kg.js/pull/44

This PR largely supports the use of `log_level` as specified in the TRAPI standard.

In the case of async, the callback and `check_query_status` will respect the original query's `log_level`. `check_query_status?log_level=DEBUG | INFO | WARNING | ERROR` may be used to specify a different log level, which will be retrieved regardless of the original query's level if specified. If not specified, the original query's log level will be respected. 