### PR TITLE
Fix #278: Add dryrun option

### DIFF
--- a/docs/smartapi.yaml
+++ b/docs/smartapi.yaml
@@ -15,7 +15,7 @@ info:
       - lookup
   x-translator:
     infores: "infores:biothings-explorer"
-    biolink-version: 2.2.8
+    biolink-version: 2.2.13
     component: ARA
     team:
       - Exploring Agent

--- a/docs/smartapi.yaml
+++ b/docs/smartapi.yaml
@@ -112,6 +112,12 @@ paths:
           required: false
           schema:
             type: boolean
+        - description: dryrun a query (logs the queries BTE will make)
+          in: query
+          name: dryrun
+          require: false
+          schema:
+            type: boolean
       requestBody:
         description: Query information to be submitted
         required: true
@@ -170,6 +176,12 @@ paths:
           in: query
           name: caching
           required: false
+          schema:
+            type: boolean
+        - description: dryrun a query (logs the queries BTE will make)
+          in: query
+          name: dryrun
+          require: false
           schema:
             type: boolean
       requestBody:
@@ -237,6 +249,12 @@ paths:
           in: query
           name: caching
           required: false
+          schema:
+            type: boolean
+        - description: dryrun a query (logs the queries BTE will make)
+          in: query
+          name: dryrun
+          require: false
           schema:
             type: boolean
       requestBody:
@@ -357,6 +375,12 @@ paths:
           required: false
           schema:
             type: boolean
+        - description: dryrun a query (logs the queries BTE will make)
+          in: query
+          name: dryrun
+          require: false
+          schema:
+            type: boolean
       requestBody:
         description: Query information to be submitted
         required: true
@@ -426,6 +450,12 @@ paths:
           in: query
           name: caching
           required: false
+          schema:
+            type: boolean
+        - description: dryrun a query (logs the queries BTE will make)
+          in: query
+          name: dryrun
+          require: false
           schema:
             type: boolean
       requestBody:
@@ -502,6 +532,12 @@ paths:
           in: query
           name: caching
           required: false
+          schema:
+            type: boolean
+        - description: dryrun a query (logs the queries BTE will make)
+          in: query
+          name: dryrun
+          require: false
           schema:
             type: boolean
       requestBody:

--- a/src/controllers/async/asyncquery.js
+++ b/src/controllers/async/asyncquery.js
@@ -93,7 +93,7 @@ exports.getQueryResponse = async (jobID, logLevel = null) => {
         if (!entries) {
             return null;
         }
-        const originalLogLevel = await redisClient.getAsync(`asyncQueryResult:logLevel:${jobID}`);
+        const originalLogLevel = JSON.parse(await redisClient.getAsync(`asyncQueryResult:logLevel:${jobID}`));
         const values = await Promise.all(JSON.parse(entries).map(async (key) => {
             const value = await new Promise(async (resolve) => {
                 const msgDecoded = Object.entries(await redisClient.hgetallAsync(`asyncQueryResult:${jobID}:${key}`))

--- a/src/controllers/async/processors/async_v1.js
+++ b/src/controllers/async/processors/async_v1.js
@@ -6,10 +6,10 @@ const predicatesPath = path.resolve(__dirname, process.env.STATIC_PATH ? `${proc
 const utils = require("../../../utils/common");
 const { asyncqueryResponse } = require("../asyncquery");
 
-async function jobToBeDone(jobID, queryGraph, caching, workflow, callback_url, jobURL = null, logLevel = null) {
+async function jobToBeDone(jobID, queryGraph, workflow, callback_url, options, jobURL = null) {
     utils.validateWorkflow(workflow);
     const handler = new TRAPIGraphHandler.TRAPIQueryHandler(
-        { apiList: config.API_LIST, caching: caching, logLevel: logLevel },
+        { apiList: config.API_LIST, ...options },
         smartAPIPath,
         predicatesPath,
     );
@@ -22,10 +22,9 @@ module.exports = async job => {
   return await jobToBeDone(
     job.id,
     job.data.queryGraph,
-    job.data.caching,
     job.data.workflow,
     job.data.callback_url,
-    job.data.url,
-    job.data.logLevel,
+    job.data.options,
+    job.data.url
   );
 };

--- a/src/controllers/async/processors/async_v1_by_api.js
+++ b/src/controllers/async/processors/async_v1_by_api.js
@@ -5,14 +5,13 @@ const predicatesPath = path.resolve(__dirname, process.env.STATIC_PATH ? `${proc
 const { asyncqueryResponse } = require('../asyncquery');
 const utils = require("../../../utils/common");
 
-async function jobToBeDone(jobID, queryGraph, smartAPIID, caching, enableIDResolution, workflow, callback_url, jobURL = null, logLevel = null){
+async function jobToBeDone(jobID, queryGraph, smartAPIID, enableIDResolution, workflow, callback_url, options, jobURL = null) {
     utils.validateWorkflow(workflow);
     const handler = new TRAPIGraphHandler.TRAPIQueryHandler(
         {
             smartAPIID,
-            caching,
-            logLevel,
-            enableIDResolution
+            enableIDResolution,
+            ...options
         },
         smartAPIPath,
         predicatesPath,
@@ -27,11 +26,10 @@ module.exports = async (job) => {
         job.id,
         job.data.queryGraph,
         job.data.smartAPIID,
-        job.data.caching,
         job.data.enableIDResolution,
         job.data.workflow,
         job.data.callback_url,
+        job.data.options,
         job.data.url,
-        job.data.logLevel,
     );
 }

--- a/src/controllers/async/processors/async_v1_by_team.js
+++ b/src/controllers/async/processors/async_v1_by_team.js
@@ -29,7 +29,7 @@ module.exports = async (job) => {
         job.data.enableIDResolution,
         job.data.workflow,
         job.data.callback_url,
-        options,
+        job.data.options,
         job.data.url,
     );
 };

--- a/src/controllers/async/processors/async_v1_by_team.js
+++ b/src/controllers/async/processors/async_v1_by_team.js
@@ -5,14 +5,13 @@ const predicatesPath = path.resolve(__dirname, process.env.STATIC_PATH ? `${proc
 const { asyncqueryResponse } = require('../asyncquery');
 const utils = require("../../../utils/common");
 
-async function jobToBeDone(jobID, queryGraph, teamName, caching, enableIDResolution, workflow, callback_url, jobURL = null, logLevel = null){
+async function jobToBeDone(jobID, queryGraph, teamName, enableIDResolution, workflow, callback_url, options, jobURL = null){
     utils.validateWorkflow(workflow);
     const handler = new TRAPIGraphHandler.TRAPIQueryHandler(
         {
             teamName,
-            caching,
-            logLevel,
-            enableIDResolution
+            enableIDResolution,
+            ...options,
         },
         smartAPIPath,
         predicatesPath,
@@ -27,11 +26,10 @@ module.exports = async (job) => {
         job.id,
         job.data.queryGraph,
         job.data.teamName,
-        job.data.caching,
         job.data.enableIDResolution,
         job.data.workflow,
         job.data.callback_url,
+        options,
         job.data.url,
-        job.data.logLevel,
     );
 };

--- a/src/routes/v1/asyncquery_v1.js
+++ b/src/routes/v1/asyncquery_v1.js
@@ -19,8 +19,7 @@ class V1RouteAsyncQuery {
                 queryGraph: req.body.message.query_graph,
                 workflow: req.body.workflow,
                 callback_url: req.body.callback_url || req.body['callback'],
-                caching: req.query.caching,
-                logLevel: req.body.log_level,
+                ...req.query
             }
             await asyncquery(req, res, next, queueData, queryQueue)
         });

--- a/src/routes/v1/asyncquery_v1.js
+++ b/src/routes/v1/asyncquery_v1.js
@@ -19,7 +19,7 @@ class V1RouteAsyncQuery {
                 queryGraph: req.body.message.query_graph,
                 workflow: req.body.workflow,
                 callback_url: req.body.callback_url || req.body['callback'],
-                ...req.query
+                options: { logLevel: req.body.log_level, ...req.query }
             }
             await asyncquery(req, res, next, queueData, queryQueue)
         });

--- a/src/routes/v1/asyncquery_v1_by_api.js
+++ b/src/routes/v1/asyncquery_v1_by_api.js
@@ -18,10 +18,9 @@ class V1RouteAsyncQueryByAPI {
             let queueData = {
                 queryGraph: req.body.message.query_graph,
                 smartAPIID: req.params.smartapi_id,
-                logLevel: req.body.log_level,
                 workflow: req.body.workflow,
                 callback_url: req.body.callback_url || req.body['callback'],
-                ...req.query,
+                options: { logLevel: req.body.log_level, ...req.query },
                 // enableIDResolution
             }
             await asyncquery(req, res, next, queueData, queryQueue)

--- a/src/routes/v1/asyncquery_v1_by_api.js
+++ b/src/routes/v1/asyncquery_v1_by_api.js
@@ -18,10 +18,10 @@ class V1RouteAsyncQueryByAPI {
             let queueData = {
                 queryGraph: req.body.message.query_graph,
                 smartAPIID: req.params.smartapi_id,
-                caching: req.query.caching,
                 logLevel: req.body.log_level,
                 workflow: req.body.workflow,
                 callback_url: req.body.callback_url || req.body['callback'],
+                ...req.query,
                 enableIDResolution
             }
             await asyncquery(req, res, next, queueData, queryQueue)

--- a/src/routes/v1/asyncquery_v1_by_team.js
+++ b/src/routes/v1/asyncquery_v1_by_team.js
@@ -18,10 +18,10 @@ class V1RouteAsyncQueryByTeam {
             let queueData = {
                 queryGraph: queryGraph,
                 teamName: req.params.team_name,
-                caching: req.query.caching,
                 logLevel: req.body.log_level,
                 workflow: req.body.workflow,
                 callback_url: req.body.callback_url || req.body['callback'],
+                ...req.query,
                 enableIDResolution
             }
             await asyncquery(req, res, next, queueData, queryQueue)

--- a/src/routes/v1/asyncquery_v1_by_team.js
+++ b/src/routes/v1/asyncquery_v1_by_team.js
@@ -21,7 +21,7 @@ class V1RouteAsyncQueryByTeam {
                 logLevel: req.body.log_level,
                 workflow: req.body.workflow,
                 callback_url: req.body.callback_url || req.body['callback'],
-                ...req.query,
+                options: { logLevel: req.body.log_level, ...req.query },
                 enableIDResolution
             }
             await asyncquery(req, res, next, queueData, queryQueue)

--- a/src/routes/v1/query_v1.js
+++ b/src/routes/v1/query_v1.js
@@ -26,7 +26,7 @@ class V1RouteQuery {
             utils.validateWorkflow(req.body.workflow);
             const queryGraph = req.body.message.query_graph;
             const handler = new TRAPIGraphHandler.TRAPIQueryHandler(
-                { apiList: config.API_LIST, caching: req.query.caching },
+                { apiList: config.API_LIST, ...req.query },
                 smartAPIPath,
                 predicatesPath,
             );

--- a/src/routes/v1/query_v1_by_api.js
+++ b/src/routes/v1/query_v1_by_api.js
@@ -27,7 +27,7 @@ class RouteQueryV1ByAPI {
             const handler = new TRAPIGraphHandler.TRAPIQueryHandler(
                 {
                     smartAPIID: req.params.smartapi_id,
-                    caching: req.query.caching,
+                    ...req.query,
                     enableIDResolution
                 },
                 smartAPIPath,

--- a/src/routes/v1/query_v1_by_team.js
+++ b/src/routes/v1/query_v1_by_team.js
@@ -27,7 +27,7 @@ class RouteQueryV1ByTeam {
             const handler = new TRAPIGraphHandler.TRAPIQueryHandler(
                 {
                     teamName: req.params.team_name,
-                    caching: req.query.caching,
+                    ...req.query,
                     enableIDResolution
                 },
                 smartAPIPath,


### PR DESCRIPTION
Fixes #278. Merge together with https://github.com/biothings/bte_trapi_query_graph_handler/pull/89.

Add support for dryrun query parameter.

Also simplified code so any future query parameters will automatically be passed to `query_graph_handler`.