### PR TITLE
PR to add drug response api to config

### DIFF
--- a/src/routes/v1/config.js
+++ b/src/routes/v1/config.js
@@ -96,6 +96,10 @@ exports.API_LIST = [
         id: '02af7d098ab304e80d6f4806c3527027',
         name: 'Multiomics Wellness KP API'
     },
+    {
+        id: 'adf20dd6ff23dfe18e8e012bde686e31',
+        name: 'Multiomics BigGIM-DrugResponse KP API'
+    },
     // Text Mining Provider collab, annotated with x-bte
     // - removed Text Mining Co-occurrence API since there were issues using it with BTE (too many answers)
     {


### PR DESCRIPTION
After talking to Guangrong: they want to see their KP being called. Making a PR to add this API to BTE...

We can batch-query this api, which is good. One issue though is that 1 chemical can retrieve > 1000 records in a query at the moment...