### PR TITLE
use an existing api in tests

### DIFF
--- a/__test__/integration/routes/v1query_by_api.test.js
+++ b/__test__/integration/routes/v1query_by_api.test.js
@@ -4,6 +4,10 @@ const fs = require("fs");
 const axios = require("axios");
 var path = require('path');
 
+//API IDs used in the tests
+const myChemAPI = "8f08d1446e0bb9c2b323713ce83e2bd3"
+const textMiningAPI = "978fe380a147a8641caf72320862697b"
+
 describe("Testing /v1/smartapi/{smartapi_id}/query endpoints", () => {
     const invalid_example_folder = path.resolve(__dirname, "../../../examples/v1.1/invalid");
     const example_folder = path.resolve(__dirname, '../../../examples/v1.1');
@@ -12,7 +16,7 @@ describe("Testing /v1/smartapi/{smartapi_id}/query endpoints", () => {
             message1: 1
         };
         await request(app)
-            .post("/v1/smartapi/8f08d1446e0bb9c2b323713ce83e2bd3/query/")
+            .post(`/v1/smartapi/${myChemAPI}/query/`)
             .send(InvalidInputQueryGraph)
             .set('Accept', 'application/json')
             .expect(400)
@@ -25,7 +29,7 @@ describe("Testing /v1/smartapi/{smartapi_id}/query endpoints", () => {
     test("Input query graph missing nodes definition should return 400", async () => {
         const query_with_nodes_undefined = JSON.parse(fs.readFileSync(path.join(invalid_example_folder, "query_graph_with_nodes_not_specified.json")));
         await request(app)
-            .post("/v1/smartapi/8f08d1446e0bb9c2b323713ce83e2bd3/query/")
+            .post(`/v1/smartapi/${myChemAPI}/query/`)
             .send(query_with_nodes_undefined)
             .set('Accept', 'application/json')
             .expect(400)
@@ -38,7 +42,7 @@ describe("Testing /v1/smartapi/{smartapi_id}/query endpoints", () => {
     test("Input query graph missing edges definition should return 400 error", async () => {
         const query_with_edges_undefined = JSON.parse(fs.readFileSync(path.join(invalid_example_folder, "query_graph_with_edges_not_specified.json")));
         await request(app)
-            .post("/v1/smartapi/8f08d1446e0bb9c2b323713ce83e2bd3/query/")
+            .post(`/v1/smartapi/${myChemAPI}/query/`)
             .send(query_with_edges_undefined)
             .set('Accept', 'application/json')
             .expect(400)
@@ -51,7 +55,7 @@ describe("Testing /v1/smartapi/{smartapi_id}/query endpoints", () => {
     test("Input query graph with nodes and edges mismatch should return 400 error", async () => {
         const query_with_nodes_and_edges_not_match = JSON.parse(fs.readFileSync(path.join(invalid_example_folder, "query_graph_with_nodes_and_edges_not_match.json")));
         await request(app)
-            .post("/v1/smartapi/8f08d1446e0bb9c2b323713ce83e2bd3/query/")
+            .post(`/v1/smartapi/${myChemAPI}/query/`)
             .send(query_with_nodes_and_edges_not_match)
             .set('Accept', 'application/json')
             .expect(400)
@@ -66,7 +70,7 @@ describe("Testing /v1/smartapi/{smartapi_id}/query endpoints", () => {
     test.skip("Query to Text Mining Targeted Association KP should have id resolution turned off", async () => {
         const query = JSON.parse(fs.readFileSync(path.join(example_folder, "textmining/query_chemicals_related_to_gene_or_gene_product.json")));
         await request(app)
-            .post("/v1/smartapi/978fe380a147a8641caf72320862697b/query/")
+            .post(`/v1/smartapi/${textMiningAPI}/query/`)
             .send(query)
             .set('Accept', 'application/json')
             .expect(200)
@@ -80,7 +84,7 @@ describe("Testing /v1/smartapi/{smartapi_id}/query endpoints", () => {
     test("Query to non-Text Mining KPs should have id resolution turned on", async () => {
         const query = JSON.parse(fs.readFileSync(path.join(example_folder, "serviceprovider/mychem.json")));
         await request(app)
-            .post("/v1/smartapi/8f08d1446e0bb9c2b323713ce83e2bd3/query")
+            .post(`/v1/smartapi/${myChemAPI}/query`)
             .send(query)
             .set('Accept', 'application/json')
             .expect(200)

--- a/__test__/integration/routes/v1query_by_api.test.js
+++ b/__test__/integration/routes/v1query_by_api.test.js
@@ -12,7 +12,7 @@ describe("Testing /v1/smartapi/{smartapi_id}/query endpoints", () => {
             message1: 1
         };
         await request(app)
-            .post("/v1/smartapi/5be0f321a829792e934545998b9c6afe/query/")
+            .post("/v1/smartapi/8f08d1446e0bb9c2b323713ce83e2bd3/query/")
             .send(InvalidInputQueryGraph)
             .set('Accept', 'application/json')
             .expect(400)
@@ -25,7 +25,7 @@ describe("Testing /v1/smartapi/{smartapi_id}/query endpoints", () => {
     test("Input query graph missing nodes definition should return 400", async () => {
         const query_with_nodes_undefined = JSON.parse(fs.readFileSync(path.join(invalid_example_folder, "query_graph_with_nodes_not_specified.json")));
         await request(app)
-            .post("/v1/smartapi/5be0f321a829792e934545998b9c6afe/query/")
+            .post("/v1/smartapi/8f08d1446e0bb9c2b323713ce83e2bd3/query/")
             .send(query_with_nodes_undefined)
             .set('Accept', 'application/json')
             .expect(400)
@@ -38,7 +38,7 @@ describe("Testing /v1/smartapi/{smartapi_id}/query endpoints", () => {
     test("Input query graph missing edges definition should return 400 error", async () => {
         const query_with_edges_undefined = JSON.parse(fs.readFileSync(path.join(invalid_example_folder, "query_graph_with_edges_not_specified.json")));
         await request(app)
-            .post("/v1/smartapi/5be0f321a829792e934545998b9c6afe/query/")
+            .post("/v1/smartapi/8f08d1446e0bb9c2b323713ce83e2bd3/query/")
             .send(query_with_edges_undefined)
             .set('Accept', 'application/json')
             .expect(400)
@@ -51,7 +51,7 @@ describe("Testing /v1/smartapi/{smartapi_id}/query endpoints", () => {
     test("Input query graph with nodes and edges mismatch should return 400 error", async () => {
         const query_with_nodes_and_edges_not_match = JSON.parse(fs.readFileSync(path.join(invalid_example_folder, "query_graph_with_nodes_and_edges_not_match.json")));
         await request(app)
-            .post("/v1/smartapi/5be0f321a829792e934545998b9c6afe/query/")
+            .post("/v1/smartapi/8f08d1446e0bb9c2b323713ce83e2bd3/query/")
             .send(query_with_nodes_and_edges_not_match)
             .set('Accept', 'application/json')
             .expect(400)


### PR DESCRIPTION
Tests on the query by api endpoint were failing since the API id specified did not exist. I have therefore changed the API ID in these tests.