### PR TITLE
use ops to determine nodes in meta knowledge graph

### DIFF
--- a/src/controllers/cron/update_local_smartapi.js
+++ b/src/controllers/cron/update_local_smartapi.js
@@ -117,7 +117,7 @@ const getOpsFromEndpoint = async (metadata) => {
         .then((res) => {
             if (res.status === 200) {
                 debug(`Successfully got ${metadata.predicates_path} for ${metadata.query_operation.server}`)
-                return { ...metadata, ...{ predicates: getPredicatesFromGraphData(metadata.predicates_path, res.data) } };
+                return { ...metadata, ...{ predicates: getPredicatesFromGraphData(metadata.predicates_path, res.data) }, nodes: res.data.nodes };
             }
             debug(
                 `[error]: API "${metadata.association.api_name}" Unable to get ${metadata.predicates_path}` +

--- a/src/controllers/meta_knowledge_graph.js
+++ b/src/controllers/meta_knowledge_graph.js
@@ -65,11 +65,6 @@ module.exports = class MetaKnowledgeGraphHandler {
         };
         let predicates = {};
         let node_sets = {};
-        // Object.keys(ids).map(semanticType => {
-        //     knowledge_graph.nodes[this._modifyCategory(semanticType)] = {
-        //         id_prefixes: ids[semanticType].id_ranks
-        //     }
-        // })
         kg.ops.map(op => {
             let input = this._modifyCategory(op.association.input_type);
             let inputID = op.association.input_id;

--- a/src/controllers/meta_knowledge_graph.js
+++ b/src/controllers/meta_knowledge_graph.js
@@ -67,9 +67,9 @@ module.exports = class MetaKnowledgeGraphHandler {
         let node_sets = {};
         kg.ops.map(op => {
             let input = this._modifyCategory(op.association.input_type);
-            let inputID = op.association.input_id;
+            let inputIDs = Array.isArray(op.association.input_id) ? op.association.input_id : [op.association.input_id];
             let output = this._modifyCategory(op.association.output_type);
-            let outputID = op.association.output_id;
+            let outputIDs = Array.isArray(op.association.output_id) ? op.association.output_id : [op.association.output_id];
             let pred = this._modifyPredicate(op.association.predicate);
 
             //edges
@@ -87,12 +87,12 @@ module.exports = class MetaKnowledgeGraphHandler {
             if (!(input in node_sets)) {
               node_sets[input] = new Set();
             }
-            node_sets[input].add(inputID)
+            inputIDs.forEach(id => id && node_sets[input].add(id))
 
             if (!(output in node_sets)) {
               node_sets[output] = new Set();
             }
-            node_sets[output].add(outputID)
+            outputIDs.forEach(id => id && node_sets[output].add(id))
         })
         Object.keys(predicates).map(input => {
             Object.keys(predicates[input]).map(output => {

--- a/src/controllers/meta_knowledge_graph.js
+++ b/src/controllers/meta_knowledge_graph.js
@@ -106,7 +106,7 @@ module.exports = class MetaKnowledgeGraphHandler {
             })
         })
         Object.keys(node_sets).map(node => {
-          knowledge_graph.nodes[node] = Array.from(node_sets[node])
+          knowledge_graph.nodes[node] = {id_prefixes: Array.from(node_sets[node])}
         })
         return knowledge_graph;
     }


### PR DESCRIPTION
Meant to fix #454. Uses subjects/objects from MetaKG operations in order to determine the nodes & node id types.
Example Query: GET ``http://localhost:3000/v1/smartapi/09c8782d9f4027712e65b95424adba79/meta_knowledge_graph`` (MyVariant)
Response:
```json
{
    "nodes": {
        "biolink:Gene": [
            "NCBIGene",
            "ENSEMBL"
        ],
        "biolink:Disease": [
            "DOID",
            "OMIM"
        ],
        "biolink:SequenceVariant": [
            "DBSNP"
        ]
    },
    "edges": [
        {
            "subject": "biolink:Gene",
            "predicate": "biolink:affects",
            "object": "biolink:Disease"
        },
        ...
    ]
}
```