### PR TITLE
Use string error code in TRAPI response for certain errors

### DIFF
--- a/src/controllers/async/asyncquery.js
+++ b/src/controllers/async/asyncquery.js
@@ -152,7 +152,7 @@ exports.asyncqueryResponse = async (handler, callback_url, jobID = null, jobURL 
         knowledge_graph: { nodes: {}, edges: {} },
         results: [],
       },
-      status: 500,
+      status: "InternalServerError",
       description: e.toString(),
       trace: process.env.NODE_ENV === "production" ? undefined : e.stack,
     };

--- a/src/controllers/async/asyncquery.js
+++ b/src/controllers/async/asyncquery.js
@@ -152,7 +152,7 @@ exports.asyncqueryResponse = async (handler, callback_url, jobID = null, jobURL 
         knowledge_graph: { nodes: {}, edges: {} },
         results: [],
       },
-      status: "InternalServerError",
+      status: "JobQueuingError",
       description: e.toString(),
       trace: process.env.NODE_ENV === "production" ? undefined : e.stack,
     };

--- a/src/controllers/async/asyncquery_queue.js
+++ b/src/controllers/async/asyncquery_queue.js
@@ -82,7 +82,7 @@ exports.getQueryQueue = name => {
                   knowledge_graph: { nodes: {}, edges: {} },
                   results: [],
                 },
-                status: "InternalServerError",
+                status: "JobQueuingError",
                 description: error.toString(),
                 trace: process.env.NODE_ENV === "production" ? undefined : error.stack,
               },

--- a/src/controllers/async/asyncquery_queue.js
+++ b/src/controllers/async/asyncquery_queue.js
@@ -82,7 +82,7 @@ exports.getQueryQueue = name => {
                   knowledge_graph: { nodes: {}, edges: {} },
                   results: [],
                 },
-                status: 500,
+                status: "InternalServerError",
                 description: error.toString(),
                 trace: process.env.NODE_ENV === "production" ? undefined : error.stack,
               },


### PR DESCRIPTION
Fixes a TRAPI validation error on responses from BTE in specific circumstances where BTE needs to represent an internal server error as a TRAPI response.

[Example failure](https://arax.ncats.io/api/arax/v1.3/response/bdca9754-0aa4-419d-8398-18d54b78e183) prior to PR.