### PR TITLE
Base query execution on thread pools

### DIFF
--- a/__test__/integration/TRAPIv1.1.test.js
+++ b/__test__/integration/TRAPIv1.1.test.js
@@ -308,7 +308,7 @@ describe("Testing v1.1 endpoints", () => {
         }
         if (qData.url === 'https://biothings.ncats.io/DISEASES/query' && qData.data === 'q=DOID:4325&scopes=DISEASES.doid') {
           res = JSON.parse(fs.readFileSync(path.resolve(__dirname, "../data/api_results/biothings_disease_query.json")))
-        } 
+        }
         if (qData.url === 'https://biothings.ncats.io/text_mining_targeted_association/query') {
           res = JSON.parse(fs.readFileSync(path.resolve(__dirname, "../../data/api_results/textmining_query.json")))
         }
@@ -429,7 +429,7 @@ describe("Testing v1.1 endpoints", () => {
             // .expect(200)
             // .expect('Content-Type', /json/)
             .then(response => {
-                console.log(response);
+                // console.log(response);
                 expect(response.body).toHaveProperty("message");
                 expect(response.body.message).toHaveProperty("query_graph");
                 expect(response.body.message).toHaveProperty("knowledge_graph");

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "node-cron": "^2.0.3",
     "npm": "^9.4.1",
     "openapi-validator-middleware": "^3.2.2",
+    "piscina": "^3.2.0",
     "ps-node": "^0.1.6",
     "snake-case": "^3.0.4",
     "stream-chunker": "^1.2.8",

--- a/src/controllers/async/asyncquery.js
+++ b/src/controllers/async/asyncquery.js
@@ -161,7 +161,7 @@ exports.asyncqueryResponse = async (handler, callback_url, jobID = null, jobURL 
       await storeQueryResponse(jobID, response);
     }
   }
-  
+
   if (callback_url) {
     if (!utils.stringIsAValidUrl(callback_url)) {
       return {

--- a/src/controllers/async/asyncquery_queue.js
+++ b/src/controllers/async/asyncquery_queue.js
@@ -5,100 +5,77 @@ const debug = require("debug")("bte:biothings-explorer-trapi:asyncquery_queue");
 const Redis = require("ioredis");
 const ps = require("ps-node");
 
-// This shouldn't be necessary, as zombie bulls *should* self-destruct.
-// essentially, this is the last-resort (and kills the job, so it perma-fails)
-let zombieCleanupAttempts = 10;
-const killZombies = () => {
-  ps.lookup(
-    {
-      arguments: "bte-trapi-workspace/node_modules/bull/lib/process/master.js",
-    },
-    (err, results) => {
-      let killed = 0;
-      results.forEach(result => {
-        if (result.ppid === "1") {
-          process.kill(result.pid, "SIGKILL");
-          killed += 1;
-        }
-      });
-      if (killed > 0) debug(`Killed ${killed} zombie Bull processors`);
-    },
-  );
-  zombieCleanupAttempts -= 1;
-  if (zombieCleanupAttempts > 0) setTimeout(killZombies, 10000);
-};
-killZombies();
-
 global.queryQueue = {};
 
 exports.getQueryQueue = name => {
   let queryQueue = null;
-  if (redisClient.clientEnabled && !process.env.INTERNAL_DISABLE_REDIS) {
-    debug(
-      `Getting queue ${name} using redis in ${process.env.REDIS_CLUSTER === "true" ? "cluster" : "non-cluster"} mode`,
-    );
-    if (!global.queryQueue[name]) {
-      debug(`Initializing queue ${name} for first time...`);
-      let details = {
-        createClient: () => {
-          const client = getNewRedisClient();
-          client.internalClient.options.enableReadyCheck = false;
-          client.internalClient.options.maxRetriesPerRequest = null;
-          return client.internalClient;
-        },
-        // createClient: () => redis.createCluster({
-        // }),
-        prefix: `{BTE:bull}`,
-      };
-      global.queryQueue[name] = new Queue(name, process.env.REDIS_HOST ? details : "redis://127.0.0.1:6379", {
-        defaultJobOptions: {
-          timeout: parseInt(process.env.JOB_TIMEOUT),
-          removeOnFail: {
-            age: 24 * 60 * 60 // keep failed jobs for a day (in case user needs to review fail reason)
-          },
-          removeOnComplete: {
-            age: 90 * 24 * 60 * 60 // keep completed jobs for 90 days
-          }
-        },
-        settings: {
-          maxStalledCount: 1,
-          //lockDuration: 300000
-          lockDuration: 3600000, // 60min
-        },
-      })
-        .on("error", function (error) {
-          console.log("err", error);
-        })
-        .on("failed", async function (job, error) {
-          const workerID = job.data.worker.threadId;
-          debug(`Async job ${job.id} failed with error ${error.message}`);
-          debug(error.stack);
-          job.data.worker
-            .terminate()
-            .then(debug(`Async worker thread ${workerID} timed out, terminated successfully.`));
-          if (job.data.callback_url) {
-            try {
-              await axios({
-                method: "post",
-                url: job.data.callback_url,
-                data: {
-                  message: {
-                    query_graph: job.data.queryGraph,
-                    knowledge_graph: { nodes: {}, edges: {} },
-                    results: [],
-                  },
-                  status: "JobQueuingError",
-                  description: error.toString(),
-                  trace: process.env.NODE_ENV === "production" ? undefined : error.stack,
-                },
-              });
-            } catch (error) {
-              debug(`Callback failed with error ${error.message}`);
-            }
-          }
-        });
-    }
-    queryQueue = global.queryQueue[name];
+  if (!redisClient.clientEnabled || process.env.INTERNAL_DISABLE_REDIS) {
+    return queryQueue;
   }
-  return queryQueue;
+  debug(
+    `Getting queue ${name} using redis in ${process.env.REDIS_CLUSTER === "true" ? "cluster" : "non-cluster"} mode`,
+  );
+  if (global.queryQueue[name]) {
+    return global.queryQueue[name];
+  }
+  debug(`Initializing queue ${name} for first time...`);
+  let details = {
+    createClient: () => {
+      const client = getNewRedisClient();
+      client.internalClient.options.enableReadyCheck = false;
+      client.internalClient.options.maxRetriesPerRequest = null;
+      return client.internalClient;
+    },
+    // createClient: () => redis.createCluster({
+    // }),
+    prefix: `{BTE:bull}`,
+  };
+  global.queryQueue[name] = new Queue(name, process.env.REDIS_HOST ? details : "redis://127.0.0.1:6379", {
+    defaultJobOptions: {
+      removeOnFail: {
+        age: 24 * 60 * 60, // keep failed jobs for a day (in case user needs to review fail reason)
+      },
+      removeOnComplete: {
+        age: 90 * 24 * 60 * 60, // keep completed jobs for 90 days
+      },
+    },
+    settings: {
+      maxStalledCount: 1,
+      //lockDuration: 300000
+      lockDuration: 3600000, // 60min
+    },
+  })
+    .on("error", function (error) {
+      console.log("err", error);
+    })
+    .on("failed", async function (job, error) {
+      debug(`Async job ${job.id} failed with error ${error.message}`);
+      try {
+        job.data.abortController.abort();
+      } catch (error) {
+        debug(error);
+      }
+      if (job.data.callback_url) {
+        try {
+          await axios({
+            method: "post",
+            url: job.data.callback_url,
+            data: {
+              message: {
+                query_graph: job.data.queryGraph,
+                knowledge_graph: { nodes: {}, edges: {} },
+                results: [],
+              },
+              status: "JobQueuingError",
+              description: error.toString(),
+              trace: process.env.NODE_ENV === "production" ? undefined : error.stack,
+            },
+          });
+        } catch (error) {
+          debug(`Callback failed with error ${error.message}`);
+        }
+      }
+    });
+
+  return global.queryQueue[name];
 };

--- a/src/controllers/async/asyncquery_queue.js
+++ b/src/controllers/async/asyncquery_queue.js
@@ -34,9 +34,11 @@ exports.getQueryQueue = name => {
     defaultJobOptions: {
       removeOnFail: {
         age: 24 * 60 * 60, // keep failed jobs for a day (in case user needs to review fail reason)
+        count: 3000 // enough to keep about 33/day for 90 days worth
       },
       removeOnComplete: {
         age: 90 * 24 * 60 * 60, // keep completed jobs for 90 days
+        count: 3000 // enough to keep about 33/day for 90 days worth
       },
     },
     settings: {

--- a/src/controllers/threading/taskHandler.js
+++ b/src/controllers/threading/taskHandler.js
@@ -1,28 +1,40 @@
-const { workerData, isMainThread, parentPort, Worker, threadId } = require("worker_threads");
+const { isMainThread, threadId } = require("worker_threads");
 const debug = require("debug")(`bte:biothings-explorer-trapi:worker${threadId}`);
 
 if (!isMainThread) { // Log thread start before BioLink model loads
-    debug(`Worker thread ${threadId} beginning task.`);
+    debug(`Worker thread ${threadId} is ready to accept tasks.`);
 }
 
 const { tasks } = require("../../routes/index");
 
-const runTask = async (req, route) => {
+const runTask = async ({req, route, port}) => {
+    debug(`Worker thread ${threadId} beginning task.`);
+    global.parentPort = port;
+    port.postMessage({ threadId, registerId: true });
+    global.cachingTasks = [];
 
     global.queryInformation = {
         queryGraph: req?.body?.message?.query_graph,
     }
 
-    if (!isMainThread) {
-        await tasks[workerData.route](workerData.req);
-        return undefined;
-    } else {
-        return await tasks[route](req);
-    }
+
+    const completedTask = await tasks[route](req);
+    await Promise.all(global.cachingTasks);
+    debug(`Worker thread ${threadId} completed task.`);
+    return completedTask;
+
+    // if (!isMainThread) {
+    //     await tasks[workerData.route](workerData.req);
+    //     return undefined;
+    // } else {
+    //     return await tasks[route](req);
+    // }
+
 }
 
-if (!isMainThread) {
-    runTask(workerData.req, workerData.route);
-}
+// if (!isMainThread) {
+//     runTask(workerData.req, workerData.route);
+// }
 
-exports.runTask = runTask;
+// exports.runTask = runTask;
+module.exports = runTask;

--- a/src/controllers/threading/threadHandler.js
+++ b/src/controllers/threading/threadHandler.js
@@ -26,7 +26,7 @@ if (!global.threadpool && !isWorkerThread && !(process.env.USE_THREADING === "fa
     sync: new Piscina({
       filename: path.resolve(__dirname, "./taskHandler.js"),
       minThreads: 2,
-      maxThreads: Math.ceil(os.cpus().length / 4),
+      // maxThreads: Math.ceil(os.cpus().length / 4),
       maxQueue: 600,
       idleTimeout: 10 * 60 * 1000, // 10 minutes
       env,
@@ -261,7 +261,7 @@ function taskError(error) {
 if (!global.queryQueue.bte_sync_query_queue && !isWorkerThread) {
   getQueryQueue("bte_sync_query_queue");
   if (global.queryQueue.bte_sync_query_queue) {
-    global.queryQueue.bte_sync_query_queue.process(Math.ceil(os.cpus().length / 4), async job => {
+    global.queryQueue.bte_sync_query_queue.process(os.cpus().length, async job => {
       return await runBullTask(job, job.data.route, false);
     });
   }

--- a/src/controllers/threading/threadHandler.js
+++ b/src/controllers/threading/threadHandler.js
@@ -26,7 +26,7 @@ if (!global.threadpool && !isWorkerThread && !(process.env.USE_THREADING === "fa
     sync: new Piscina({
       filename: path.resolve(__dirname, "./taskHandler.js"),
       minThreads: 2,
-      // maxThreads: Math.ceil(os.cpus().length / 4),
+      maxThreads: Math.ceil(os.cpus().length * 0.75), // on 8 cores, 24 given 4 instances
       maxQueue: 600,
       idleTimeout: 10 * 60 * 1000, // 10 minutes
       env,
@@ -37,7 +37,7 @@ if (!global.threadpool && !isWorkerThread && !(process.env.USE_THREADING === "fa
      */
     async: new Piscina({
       filename: path.resolve(__dirname, "./taskHandler.js"),
-      maxThreads: 3, // only 3 job queues allowing only 1 execution at a time each
+      maxThreads: 6, // 3 job queues allowing concurrency of 2
       minThreads: 1,
       idleTimeout: 60 * 60 * 1000, // 1 hour
       env,
@@ -261,7 +261,7 @@ function taskError(error) {
 if (!global.queryQueue.bte_sync_query_queue && !isWorkerThread) {
   getQueryQueue("bte_sync_query_queue");
   if (global.queryQueue.bte_sync_query_queue) {
-    global.queryQueue.bte_sync_query_queue.process(os.cpus().length, async job => {
+    global.queryQueue.bte_sync_query_queue.process(Math.ceil(os.cpus().length * 0.75), async job => {
       return await runBullTask(job, job.data.route, false);
     });
   }

--- a/src/controllers/threading/threadHandler.js
+++ b/src/controllers/threading/threadHandler.js
@@ -1,61 +1,131 @@
-const { Worker, parentPort } = require("worker_threads");
+const { MessageChannel, threadId } = require("worker_threads");
 const debug = require("debug")("bte:biothings-explorer-trapi:threading");
 const path = require("path");
 // const taskHandler = require("./taskHandler");
 const { redisClient } = require("@biothings-explorer/query_graph_handler");
+const Piscina = require("piscina");
+const { isWorkerThread } = require("piscina");
+const EventEmitter = require("events");
+const os = require("os");
+const ServerOverloadedError = require("../../utils/errors/server_overloaded_error");
+const { customAlphabet } = require("nanoid");
+const { getQueryQueue } = require("../async/asyncquery_queue");
 
-const createNewWorker = async (req, route, job) => {
-  return new Promise((resolve, reject) => {
-    const worker = new Worker(path.resolve(__dirname, "./taskHandler.js"), {
-      workerData: { req: req, route: route },
-    });
+if (!global.threadpool && !isWorkerThread && !(process.env.USE_THREADING === "false")) {
+  const env = {
+    ...process.env,
+    DEBUG_COLORS: true,
+  };
+  global.threadpool = {
+    /**Medium-volume, medium-intensity requests
+     * Maximum threads equal to 1/4 CPUs as BTE usually runs 4 intances
+     * Maximum queue set, so if the queue if full, requests will be dropped
+     * Usually, queuing will be handled by Bull, but if Bull is unavailable
+     * (e.g. local debugging w/o a Redis instance), queuing falls back to Piscina
+     */
+    sync: new Piscina({
+      filename: path.resolve(__dirname, "./taskHandler.js"),
+      minThreads: 2,
+      maxThreads: Math.ceil(os.cpus().length / 4),
+      maxQueue: 600,
+      idleTimeout: 10 * 60 * 1000, // 10 minutes
+      env,
+    }),
+    /**Low-volume, high-intensity requests
+     * No other settings since this queue is handled externally with Bull
+     * High timeout because we expect near-constant use, so rather not kill the thread
+     */
+    async: new Piscina({
+      filename: path.resolve(__dirname, "./taskHandler.js"),
+      maxThreads: 3, // only 3 job queues allowing only 1 execution at a time each
+      minThreads: 1,
+      idleTimeout: 60 * 60 * 1000, // 1 hour
+      env,
+    }),
+    /**High-volume, low-intensity requests
+     * Expecting frequent use, so timeout is high
+     */
+    misc: new Piscina({
+      filename: path.resolve(__dirname, "./taskHandler.js"),
+      idleTimeout: 60 * 60 * 1000, // 1 hour
+      minThreads: 2,
+      maxQueue: 600,
+      env,
+    }),
+  };
+}
+
+const queueTaskToWorkers = async (pool, req, route, job) => {
+  return new Promise(async (resolve, reject) => {
+    let WorkerThreadID;
+    const abortController = new AbortController();
+    const { port1: toWorker, port2: fromWorker } = new MessageChannel();
+    const task = pool.run({ req, route, port: toWorker }, { signal: abortController.signal, transferList: [toWorker] });
     if (job) {
-      job.update({ ...job.data, worker });
+      job.update({ ...job.data, abortController });
     }
+
+    // catch failures that cause the worker to outright fail
+    task.catch(error => {
+      if (error.name === "AbortError") {
+        debug(`Worker thread ${WorkerThreadID} terminated successfully.`);
+      } else if (error.message === "Task queue is at limit") {
+        debug(
+          [pool === global.threadpool.sync ? "Synchronous" : "Misc", "server queue is at limit, job rejected."].join(
+            " ",
+          ),
+        );
+        const expectedWaitTime = Math.ceil(pool.waitTime.p99 / 1000) + 1;
+        const message = [
+          "The server is currently under heavy load.",
+          ` Please try again after about ${expectedWaitTime}s`,
+          pool === global.threadpool.sync ? ", or try using the asynchronous endpoints." : ".",
+        ].join("");
+        error = new ServerOverloadedError(message, expectedWaitTime);
+      } else {
+        debug(`Caught error in worker thread ${WorkerThreadID}, error below:`);
+        debug(error);
+      }
+      reject(error);
+    });
     let reqDone = false;
     let cacheInProgress = 0;
     let cacheKeys = {};
     const timeout = parseInt(process.env.REQUEST_TIMEOUT) * 1000;
-    worker.on("message", (...args) => {
-      const workerID = worker.threadId;
-      if (args[0].cacheInProgress) {
+    fromWorker.on("message", ({ threadId, ...msg }) => {
+      if (msg.cacheInProgress) {
         // cache handler has started caching
         cacheInProgress += 1;
-      } else if (args[0].addCacheKey) {
+      } else if (msg.addCacheKey) {
         // hashed edge id cache in progress
-        cacheKeys[args[0].cacheKey] = false;
-      } else if (args[0].completeCacheKey) {
+        cacheKeys[msg.cacheKey] = false;
+      } else if (msg.completeCacheKey) {
         // hashed edge id cache complete
-        cacheKeys[args[0].cacheKey] = true;
-      } else if (typeof args[0].cacheDone !== "undefined") {
-        cacheInProgress = args[0].cacheDone
+        cacheKeys[msg.cacheKey] = true;
+      } else if (msg.registerId) {
+        if (job) {
+          WorkerThreadID = threadId;
+          job.update({ ...job.data, threadId });
+        }
+      } else if (typeof msg.cacheDone !== "undefined") {
+        cacheInProgress = msg.cacheDone
           ? cacheInProgress - 1 // a caching handler has finished caching
           : 0; // caching has been entirely cancelled
-      } else if (typeof args[0].msg !== "undefined") {
+      } else if (typeof msg.result !== "undefined") {
         // request has finished with a message
         reqDone = true;
-        resolve(...args);
-      } else if (args[0].err) {
+        resolve(msg);
+      } else if (msg.err) {
+        // request has resulted in a catchable error
         reqDone = true;
-        reject(args[0].err);
+        reject(msg.err);
       }
-      if (reqDone && cacheInProgress <= 0) {
-        worker.terminate().then(() => debug(`Worker thread ${workerID} completed task, terminated successfully.`));
-        if (job) {
-          job.progress(100);
-        }
+      if (reqDone && cacheInProgress <= 0 && job) {
+        job.progress(100);
       }
     });
-    worker.on("error", (...args) => {
-      reqDone = true; // allows caching to finish if any was started.
-      reject(...args);
-    });
-    worker.on("exit", code => {
-      if (code !== 0) {
-        reject(new Error(`Worker ${worker.threadId} exited with code ${code}`));
-      }
-    });
-    if (timeout && !job) {
+
+    if (timeout && pool !== global.threadpool.async) {
       setTimeout(() => {
         // clean up any incompletely cached hashes to avoid issues pulling from cache
         const activeKeys = Object.entries(cacheKeys).filter(([key, complete]) => !complete);
@@ -66,7 +136,7 @@ const createNewWorker = async (req, route, job) => {
             null;
           }
         }
-        worker.terminate();
+        abortController.abort();
         reject(
           new Error(
             `Request timed out (exceeded time limit of ${
@@ -79,70 +149,127 @@ const createNewWorker = async (req, route, job) => {
   });
 };
 
-module.exports = {
-  runTask: async (req, task, route, res = undefined) => {
-    return new Promise(async (resolve, reject) => {
-      try {
-        req = {
-          // obj communicable between threads
-          body: req.body,
-          headers: req.headers,
-          host: req.hostname,
-          method: req.method,
-          params: req.params,
-          path: req.path,
-          query: req.query,
-          rateLimit: req.rateLimit,
-          schema: req.schema,
-        };
-        if (!(process.env.USE_THREADING === "false")) {
-          const response = await createNewWorker(req, route);
-          if (typeof response.msg !== "undefined") {
-            if (response.status) {
-              res?.status(response.status);
-            }
-            resolve(response.msg ? response.msg : undefined); // null msg means keep response body empty
-          } else if (response.err) {
-            reject(response.err);
-          } else {
-            reject(new Error("Threading Error: Task resolved without message"));
-          }
-        } else {
-          const response = await task(req);
-          resolve(response);
-        }
-      } catch (error) {
-        reject(error);
+async function runTask(req, task, route, res, useBullSync = true) {
+  const queryQueue = global.queryQueue.bte_sync_query_queue;
+  req = {
+    data: {
+      route,
+      queryGraph: req.body.message?.query_graph,
+      workflow: req.body.workflow,
+      options: {
+        logLevel: req.body.log_level,
+        submitter: req.body.submitter,
+        smartAPIID: req.params.smartapi_id,
+        teamName: req.params.team_name,
+        ...req.query,
+      },
+    },
+    params: req.params,
+  };
+  if (queryQueue && useBullSync) {
+    const nanoid = customAlphabet("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", 10);
+    const jobId = nanoid();
+    const jobOpts = { jobId, attempts: 1, timeout: undefined };
+
+    if ((await queryQueue.count()) >= 600) {
+      const pool = global.threadpool.sync;
+      const expectedWaitTime = Math.ceil(pool.waitTime.p99 / 1000) + 1;
+      const message = [
+        "The server is currently under heavy load.",
+        ` Please try again after about ${expectedWaitTime}s`,
+        ", or try using the asynchronous endpoints.",
+      ].join("");
+      throw new ServerOverloadedError(message, expectedWaitTime);
+    }
+
+    try {
+      const job = await queryQueue.add(req.data, jobOpts);
+      const response = await job.finished();
+      return response;
+    } catch (error) {
+      throw error;
+    }
+  }
+  // redis unavailable or query not to sync queue such as check_query_status
+  if (!(process.env.USE_THREADING === "false")) {
+    const response = await queueTaskToWorkers(
+      useBullSync ? global.threadpool.sync : global.threadpool.misc,
+      req,
+      route,
+    );
+    if (typeof response.result !== "undefined") {
+      if (response.status) {
+        res?.status(response.status);
       }
-    });
-  },
-  runAsyncTask: async (job, route) => {
-    const req = { id: job.id, data: { ...job.data } };
-    const response = await createNewWorker(req, route, job);
-    return new Promise((resolve, reject) => {
-      if (typeof response.msg !== "undefined") {
-        resolve(response.msg ? response.msg : undefined); // null msg means keep response body empty
+      return response.result ? response.result : undefined; // null msg means keep response body empty
+    } else if (response.err) {
+      throw new response.err();
+    } else {
+      throw new Error("Threading Error: Task resolved without message");
+    }
+  }
+  // threading disabled
+  try {
+    const response = await task(req);
+    return response;
+  } catch (error) {
+    throw error;
+  }
+}
+
+async function runBullTask(job, route, async = true) {
+  const req = { id: job.id, data: { ...job.data } };
+  return new Promise(async (resolve, reject) => {
+    try {
+      const response = await queueTaskToWorkers(
+        async ? global.threadpool.async : global.threadpool.sync,
+        req,
+        route,
+        job,
+      );
+      if (typeof response.result !== "undefined") {
+        resolve(response.result ? response.result : undefined); // null result means keep response body empty
       } else if (response.err) {
         reject(response.err);
       } else {
         reject(new Error("Threading Error: Task resolved without message"));
       }
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+function taskResponse(response, status = undefined) {
+  if (global.parentPort) {
+    global.parentPort.postMessage({ threadId, result: response, status: status });
+    return undefined;
+  } else {
+    return response;
+  }
+}
+
+function taskError(error) {
+  if (global.parentPort) {
+    global.parentPort.postMessage({ threadId, err: error });
+    return undefined;
+  } else {
+    throw error;
+  }
+}
+
+if (!global.queryQueue.bte_sync_query_queue && !isWorkerThread) {
+  getQueryQueue("bte_sync_query_queue");
+  if (global.queryQueue.bte_sync_query_queue) {
+    global.queryQueue.bte_sync_query_queue.process(Math.ceil(os.cpus().length / 4), async job => {
+      return await runBullTask(job, job.data.route, false);
     });
-  },
-  taskResponse: (response, status = undefined) => {
-    if (parentPort) {
-      parentPort.postMessage({ msg: response, status: status });
-      return undefined;
-    } else {
-      return response;
-    }
-  },
-  taskError: error => {
-    if (parentPort) {
-      parentPort.postMessage({ err: error });
-      return undefined;
-    } else {
-      throw error;
-    }
-  },
+  }
+}
+
+module.exports = {
+  runTask,
+  runBullTask,
+  taskResponse,
+  taskError,
 };

--- a/src/middlewares/error.js
+++ b/src/middlewares/error.js
@@ -1,58 +1,63 @@
-const swaggerValidation = require('./validate');
+const swaggerValidation = require("./validate");
 const QueryGraphHandler = require("@biothings-explorer/query_graph_handler");
-const PredicatesLoadingError = require('../utils/errors/predicates_error');
+const PredicatesLoadingError = require("../utils/errors/predicates_error");
 const MetaKGLoadingError = require("../utils/errors/metakg_error");
+const ServerOverloadedError = require("../utils/errors/server_overloaded_error");
 const debug = require("debug")("bte:biothings-explorer-trapi:error_handler");
 class ErrorHandler {
-    setRoutes(app) {
-        app.use((error, req, res, next) => {
-            if (error instanceof swaggerValidation.InputValidationError) {
-                return res.status(400).json({
-                    error: "Your input query graph is invalid",
-                    more_info: error.errors
-                });
-            }
-            // read stack when instance or err is broken
-            if (error instanceof QueryGraphHandler.InvalidQueryGraphError ||
-                error.stack.includes("InvalidQueryGraphError")) {
-                return res.status(400).json({
-                    error: "Your input query graph is invalid",
-                    more_info: error.message
-                })
-            }
-            if (error instanceof PredicatesLoadingError) {
-                return res.status(404).json({
-                    error: "Unable to load predicates",
-                    more_info: error.message
-                })
-            }
-
-            if (error instanceof MetaKGLoadingError) {
-                return res.status(404).json({
-                    error: "Unable to load metakg",
-                    more_info: error.message
-                })
-            }
-            if (!error.statusCode) error.statusCode = 500;
-
-            if (error.statusCode === 301) {
-                return res.status(301).redirect('/');
-            }
-            debug(error);
-            return res
-                .status(error.statusCode)
-                .json({
-                    message: {
-                        query_graph: req.body?.message?.query_graph,
-                        knowledge_graph: { nodes: {}, edges: {} },
-                        results: []
-                    },
-                    status: error.statusCode,
-                    description: error.toString(),
-                    trace: process.env.NODE_ENV === 'production' ? undefined : error.stack
-                });
+  setRoutes(app) {
+    app.use((error, req, res, next) => {
+      if (error instanceof swaggerValidation.InputValidationError) {
+        return res.status(400).json({
+          error: "Your input query graph is invalid",
+          more_info: error.errors,
         });
-    }
+      }
+      // read stack when instance or err is broken
+      if (error instanceof QueryGraphHandler.InvalidQueryGraphError || error.stack.includes("InvalidQueryGraphError")) {
+        return res.status(400).json({
+          error: "Your input query graph is invalid",
+          more_info: error.message,
+        });
+      }
+      if (error instanceof PredicatesLoadingError) {
+        return res.status(404).json({
+          error: "Unable to load predicates",
+          more_info: error.message,
+        });
+      }
+
+      if (error instanceof MetaKGLoadingError) {
+        return res.status(404).json({
+          error: "Unable to load metakg",
+          more_info: error.message,
+        });
+      }
+
+      if (error instanceof ServerOverloadedError) {
+        return res.status(503).set("Retry-After", error.retryAfter).json({
+          error: "Server is overloaded",
+          more_info: error.message,
+        });
+      }
+      if (!error.statusCode) error.statusCode = 500;
+
+      if (error.statusCode === 301) {
+        return res.status(301).redirect("/");
+      }
+      debug(error);
+      return res.status(error.statusCode).json({
+        message: {
+          query_graph: req.body?.message?.query_graph,
+          knowledge_graph: { nodes: {}, edges: {} },
+          results: [],
+        },
+        status: error.statusCode,
+        description: error.toString(),
+        trace: process.env.NODE_ENV === "production" ? undefined : error.stack,
+      });
+    });
+  }
 }
 
 module.exports = new ErrorHandler();

--- a/src/routes/bullboard.js
+++ b/src/routes/bullboard.js
@@ -21,9 +21,10 @@ class RouteBullBoardPage {
       return;
     }
     const queues = {
-      "/v1/asyncquery": getQueryQueue("bte_query_queue"),
+      "/v1/asynquery": getQueryQueue("bte_query_queue"),
       "/v1/smartapi/{smartapi_id}/asyncquery": getQueryQueue("bte_query_queue_by_api"),
       "/v1/team/{team_name}/asyncquery": getQueryQueue("bte_query_queue_by_team"),
+      "/v1/query": getQueryQueue("bte_sync_query_queue"),
     };
 
     const serverAdapter = new ExpressAdapter();
@@ -42,8 +43,11 @@ class RouteBullBoardPage {
           readOnlyMode: true,
           description: name,
         });
-        adapter.setFormatter("name", job => `Asynchronous Request #${job.id}`);
-        adapter.setFormatter("data", ({ worker, ...rest }) => rest);
+        adapter.setFormatter(
+          "name",
+          job => `${name === "/v1/query" ? "Synchronous" : "Asynchronous"} Request #${job.id}`,
+        );
+        adapter.setFormatter("data", ({ abortController, threadId, route, ...rest }) => rest);
         return adapter;
       }),
       serverAdapter,

--- a/src/routes/v1/asyncquery_v1.js
+++ b/src/routes/v1/asyncquery_v1.js
@@ -6,7 +6,7 @@ const utils = require("../../utils/common");
 const { isMainThread } = require("worker_threads");
 const { TRAPIQueryHandler } = require("@biothings-explorer/query_graph_handler");
 const { API_LIST: apiList } = require("../../config/apis");
-const { taskResponse, runAsyncTask } = require("../../controllers/threading/threadHandler");
+const { taskResponse, runBullTask } = require("../../controllers/threading/threadHandler");
 const smartAPIPath = path.resolve(
   __dirname,
   process.env.STATIC_PATH ? `${process.env.STATIC_PATH}/data/smartapi_specs.json` : "../../../data/smartapi_specs.json",
@@ -16,11 +16,11 @@ const predicatesPath = path.resolve(
   process.env.STATIC_PATH ? `${process.env.STATIC_PATH}/data/predicates.json` : "../../../data/predicates.json",
 );
 
-if (!global.queryQueue["bte_query_queue"] && isMainThread) {
+if (!global.queryQueue.bte_query_queue && isMainThread) {
   getQueryQueue("bte_query_queue");
-  if (global.queryQueue["bte_query_queue"]) {
-    global.queryQueue["bte_query_queue"].process(async job => {
-      return await runAsyncTask(job, path.parse(__filename).name);
+  if (global.queryQueue.bte_query_queue) {
+    global.queryQueue.bte_query_queue.process(async job => {
+      return await runBullTask(job, path.parse(__filename).name);
     });
     // path.resolve(__dirname, "../../controllers/async/processors/async_v1.js"),
   }

--- a/src/routes/v1/asyncquery_v1.js
+++ b/src/routes/v1/asyncquery_v1.js
@@ -19,7 +19,7 @@ const predicatesPath = path.resolve(
 if (!global.queryQueue.bte_query_queue && isMainThread) {
   getQueryQueue("bte_query_queue");
   if (global.queryQueue.bte_query_queue) {
-    global.queryQueue.bte_query_queue.process(async job => {
+    global.queryQueue.bte_query_queue.process(2, async job => {
       return await runBullTask(job, path.parse(__filename).name);
     });
     // path.resolve(__dirname, "../../controllers/async/processors/async_v1.js"),

--- a/src/routes/v1/asyncquery_v1_by_api.js
+++ b/src/routes/v1/asyncquery_v1_by_api.js
@@ -19,7 +19,7 @@ const predicatesPath = path.resolve(
 if (!global.queryQueue.bte_query_queue_by_api && isMainThread) {
   getQueryQueue("bte_query_queue_by_api");
   if (global.queryQueue.bte_query_queue_by_api) {
-    global.queryQueue.bte_query_queue_by_api.process(async job => {
+    global.queryQueue.bte_query_queue_by_api.process(2, async job => {
       return await runBullTask(job, path.parse(__filename).name);
     });
   }

--- a/src/routes/v1/asyncquery_v1_by_api.js
+++ b/src/routes/v1/asyncquery_v1_by_api.js
@@ -6,7 +6,7 @@ const utils = require("../../utils/common");
 const { isMainThread } = require("worker_threads");
 const { TRAPIQueryHandler } = require("@biothings-explorer/query_graph_handler");
 const { API_LIST: apiList } = require("../../config/apis");
-const { taskResponse, runAsyncTask } = require("../../controllers/threading/threadHandler");
+const { taskResponse, runBullTask } = require("../../controllers/threading/threadHandler");
 const smartAPIPath = path.resolve(
   __dirname,
   process.env.STATIC_PATH ? `${process.env.STATIC_PATH}/data/smartapi_specs.json` : "../../../data/smartapi_specs.json",
@@ -16,11 +16,11 @@ const predicatesPath = path.resolve(
   process.env.STATIC_PATH ? `${process.env.STATIC_PATH}/data/predicates.json` : "../../../data/predicates.json",
 );
 
-if (!global.queryQueue["bte_query_queue_by_api"] && isMainThread) {
+if (!global.queryQueue.bte_query_queue_by_api && isMainThread) {
   getQueryQueue("bte_query_queue_by_api");
-  if (global.queryQueue["bte_query_queue_by_api"]) {
-    global.queryQueue["bte_query_queue_by_api"].process(async job => {
-      return await runAsyncTask(job, path.parse(__filename).name);
+  if (global.queryQueue.bte_query_queue_by_api) {
+    global.queryQueue.bte_query_queue_by_api.process(async job => {
+      return await runBullTask(job, path.parse(__filename).name);
     });
   }
 }

--- a/src/routes/v1/asyncquery_v1_by_team.js
+++ b/src/routes/v1/asyncquery_v1_by_team.js
@@ -6,7 +6,7 @@ const utils = require("../../utils/common");
 const { isMainThread } = require("worker_threads");
 const { TRAPIQueryHandler } = require("@biothings-explorer/query_graph_handler");
 const { API_LIST: apiList } = require("../../config/apis");
-const { taskResponse, runAsyncTask } = require("../../controllers/threading/threadHandler");
+const { taskResponse, runBullTask } = require("../../controllers/threading/threadHandler");
 const smartAPIPath = path.resolve(
   __dirname,
   process.env.STATIC_PATH ? `${process.env.STATIC_PATH}/data/smartapi_specs.json` : "../../../data/smartapi_specs.json",
@@ -16,11 +16,11 @@ const predicatesPath = path.resolve(
   process.env.STATIC_PATH ? `${process.env.STATIC_PATH}/data/predicates.json` : "../../../data/predicates.json",
 );
 
-if (!global.queryQueue["bte_query_queue_by_team"] && isMainThread) {
+if (!global.queryQueue.bte_query_queue_by_team && isMainThread) {
   getQueryQueue("bte_query_queue_by_team");
-  if (global.queryQueue["bte_query_queue_by_team"]) {
-    global.queryQueue["bte_query_queue_by_team"].process(async job => {
-      return await runAsyncTask(job, path.parse(__filename).name);
+  if (global.queryQueue.bte_query_queue_by_team) {
+    global.queryQueue.bte_query_queue_by_team.process(async job => {
+      return await runBullTask(job, path.parse(__filename).name);
     });
   }
 }

--- a/src/routes/v1/asyncquery_v1_by_team.js
+++ b/src/routes/v1/asyncquery_v1_by_team.js
@@ -19,7 +19,7 @@ const predicatesPath = path.resolve(
 if (!global.queryQueue.bte_query_queue_by_team && isMainThread) {
   getQueryQueue("bte_query_queue_by_team");
   if (global.queryQueue.bte_query_queue_by_team) {
-    global.queryQueue.bte_query_queue_by_team.process(async job => {
+    global.queryQueue.bte_query_queue_by_team.process(2, async job => {
       return await runBullTask(job, path.parse(__filename).name);
     });
   }

--- a/src/routes/v1/check_query_status.js
+++ b/src/routes/v1/check_query_status.js
@@ -17,7 +17,7 @@ class VCheckQueryStatus {
       .route("/v1/check_query_status/:id")
       .get(swaggerValidation.validate, async (req, res, next) => {
         try {
-          const response = await runTask(req, this.task, path.parse(__filename).name, res);
+          const response = await runTask(req, this.task, path.parse(__filename).name, res, false);
           res.setHeader("Content-Type", "application/json");
           res.end(JSON.stringify(response));
         } catch (err) {
@@ -31,7 +31,7 @@ class VCheckQueryStatus {
     //logger.info("query /query endpoint")
     try {
       debug(`checking query status of job ${req.params.id}`);
-      let by = req.query.by;
+      let by = req.data.options.by;
       let id = req.params.id;
       let queryQueue;
       if (redisClient.clientEnabled) {
@@ -62,7 +62,7 @@ class VCheckQueryStatus {
                 taskResponse({
                   id,
                   state,
-                  reason: `This job was stopped after running over ${parseInt(process.env.JOB_TIMEOUT) / 1000}s`,
+                  reason: `Job was stopped after exceeding time limit of ${parseInt(process.env.JOB_TIMEOUT) / 1000}s`,
                 });
               } catch (e) {
                 taskResponse({ id, state, reason });
@@ -72,7 +72,7 @@ class VCheckQueryStatus {
           }
           let returnvalue = job.returnvalue;
           if (returnvalue?.response && !returnvalue?.response?.error) {
-            const storedResponse = await getQueryResponse(id, req.query.log_level);
+            const storedResponse = await getQueryResponse(id, req.data.options.logLevel);
             if (storedResponse) {
               returnvalue.response = storedResponse;
             } else {

--- a/src/routes/v1/query_v1_by_team.js
+++ b/src/routes/v1/query_v1_by_team.js
@@ -30,19 +30,17 @@ class RouteQueryV1ByTeam {
       .all(utils.methodNotAllowed);
   }
 
-  async task(req) {
+  async task(job) {
+    const queryGraph = job.data.queryGraph,
+      workflow = job.data.workflow,
+      options = { ...job.data.options, schema: await utils.getSchema() };
     try {
-      utils.validateWorkflow(req.body.workflow);
-      const queryGraph = req.body.message.query_graph;
+      utils.validateWorkflow(workflow);
       // const enableIDResolution = (req.params.team_name === "Text Mining Provider") ? false : true;
       const handler = new TRAPIGraphHandler.TRAPIQueryHandler(
         {
-          apiList,
-          teamName: req.params.team_name,
-          submitter: req.body.submitter,
-          ...req.query,
+          ...options,
           enableIDResolution: true,
-          schema: req.schema,
         },
         smartAPIPath,
         predicatesPath,
@@ -51,7 +49,7 @@ class RouteQueryV1ByTeam {
       handler.setQueryGraph(queryGraph);
       await handler.query();
       const response = handler.getResponse();
-      utils.filterForLogLevel(response, req.body.log_level);
+      utils.filterForLogLevel(response, options.logLevel);
       return taskResponse(response);
     } catch (error) {
       return taskError(error);

--- a/src/utils/errors/server_overloaded_error.js
+++ b/src/utils/errors/server_overloaded_error.js
@@ -1,0 +1,11 @@
+class ServerOverloadedError extends Error {
+  constructor(message, retryAfter, ...params) {
+    super(params);
+    this.name = "ServerOverloadedError";
+    this.message = message ?? "Server is overloaded, please try again later.";
+    this.status = 503;
+    this.retryAfter = retryAfter ?? 60;
+  }
+}
+
+module.exports = ServerOverloadedError;


### PR DESCRIPTION
Currently, BTE executes all v1 queries in a thread, with a new thread being spawned for each query. For async, this is limited to one at a time by Bull, however for sync and check_query_status, the number of possible threads is unbound, meaning BTE could suffer very high traffic from multiple sources and run out of memory.

This PR does a few things:
- All query execution is now backed by Piscina thread pools.
  - Async gets up to 3 threads: one for each async queue.
  - Sync gets up to 1/4 of available CPU threads for simultaneous execution.
  - check_query_status can have as many threads as CPU cores as it's lightweight.
- Sync queries now use a bull queue which can be tracked on the dashboard.
  - If redis is unavailable (local testing, etc) this falls back to Piscina queuing.
  - If threading is disabled, sync queries still fall back to normal async/await execution.
  - As before, if redis is enabled, threading must be enabled.
- Sync queries, as well as check_query_status, now have a maximum queue of 600.
  - If queue is full, new queries will receive HTTP 503 and a message and header to try again after a time.
  - Time to try again is determined by 99th percentile execution time of the related thread pool.
  - Due to quirks of Bull behavior, dropped queries will not be saved to the bull queue and cannot be tracked.
  
Requires biothings/bte_trapi_query_graph_handler#142, recommend biothings/bte-trapi-workspace#23 
