### PR TITLE
TRAPI 1.4: overrides/KP swaps and other bits for migration

### DIFF
--- a/docs/smartapi.yaml
+++ b/docs/smartapi.yaml
@@ -1,15 +1,21 @@
 openapi: 3.0.3
 info:
+  description: A TRAPI/Reasoner Standard API for BioThings Explorer (BTE)
+  version: 2.8.1
+  title: BioThings Explorer (BTE) TRAPI
   contact:
     email: asu@scripps.edu
     name: Andrew Su
     url: https://github.com/andrewsu
-  description: A TRAPI/Reasoner Standard API for BioThings Explorer (BTE)
   termsOfService: https://biothings.io/about
-  title: BioThings Explorer (BTE) TRAPI
-  version: 2.8.1
+  x-translator:
+    component: ARA
+    team:
+      - Exploring Agent
+    biolink-version: "3.1.1"
+    infores: "infores:biothings-explorer"
   x-trapi:
-    version: 1.3.0
+    version: 1.4.0
     asyncquery: true
     operations:
     ## look at https://standards.ncats.io/operation.json for details.
@@ -20,36 +26,23 @@ info:
     ## /meta_knowledge_graph endpoints have a limit of 30 requests/client/min
     ## other endpoints don't have rate limits
     rate_limit: 15
-    ## test_data_location not included for now
-  x-translator:
-    infores: "infores:biothings-explorer"
-    biolink-version: "3.1.1"
-    component: ARA
-    team:
-      - Exploring Agent
+    test_data_location: 
+      default: 
+        url: "https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/master/biothings_explorer/sri-test-bte-ara.json"
 servers:
-## ITRB Production and Test are deployed manually, based on the staging instance
-## ITRB CI / staging is basically deployed manually, from main branches
-## - automatic for updates in bte-trapi-workspace main branch, but those rarely happen
-## - we could technically control what branches are used (but right now we don't do this)
-## non-ITRB dev: total manual control on updates (what branches of modules are used for updates)
-- url: https://bte.transltr.io/v1
-  description: ITRB Production server
-  x-maturity: production
-- url: https://bte.test.transltr.io/v1
-  description: ITRB Test server
-  x-maturity: testing
-- url: https://bte.ci.transltr.io/v1
-  description: ITRB CI server
-  x-maturity: staging
+## ITRB Production and Test deployments are made by ITRB, based on the staging instance
+## ITRB CI / staging deployments are made by our team (will add details later)
+## non-ITRB dev: deployments are made by our team
+##               we have full control on when / what branches for modules are used
 - url: https://api.bte.ncats.io/v1
   description: Non-ITRB dev (internal use)
   x-maturity: development
 tags:
-- name: 1.3.0
+- name: 1.4.0
 - name: meta_knowledge_graph
 - name: query
 - name: asyncquery
+- name: asyncquery_status
 - name: translator
 - name: trapi
 - name: biothings
@@ -107,8 +100,7 @@ paths:
             Translator Team Name. Current options: Service Provider, Multiomics Provider, Text Mining Provider.
             The easiest way to find what KP APIs would be included under these teams is to read the list of APIs BTE uses
             https://github.com/biothings/biothings_explorer/blob/main/src/config/apis.js.
-            Note that Service Provider endpoints are also advertised separately as a KP
-            http://smart-api.info/registry?q=36f82f05705c317bac17ddae3a0ea2f0
+            Note that Service Provider endpoints are also registered separately as a KP in the SmartAPI Registry
           in: path
           name: team_name
           required: true
@@ -331,8 +323,7 @@ paths:
             Translator Team Name. Current options: Service Provider, Multiomics Provider, Text Mining Provider.
             The easiest way to find what KP APIs would be included under these teams is to read the list of APIs BTE uses
             https://github.com/biothings/biothings_explorer/blob/main/src/config/apis.js.
-            Note that Service Provider endpoints are also advertised separately as a KP
-            http://smart-api.info/registry?q=36f82f05705c317bac17ddae3a0ea2f0
+            Note that Service Provider endpoints are also registered separately as a KP in the SmartAPI Registry
           in: path
           name: team_name
           required: true
@@ -440,9 +431,9 @@ paths:
           type: string
     get:
       tags:
-        - asyncquery
+        - asyncquery_status
       summary: >-
-        This endpoint should be used when a Query was sent to BTE through an /asyncquery
+        This endpoint can be used when a Query was sent to BTE through an /asyncquery
         endpoint without a callback property: BTE then handled it in a polling manner and
         provided a job id. The job id can be used here to check the status or retrieve
         the Response.
@@ -454,7 +445,7 @@ paths:
           schema:
             type: string
             description: >-
-              Logging level. The order of priority is ERROR, WARNING, INFO, DEBUG. BTE will return all logs at the
+              Logging level. The order of priority is ERROR, WARNING, INFO, DEBUG. BTE will return all logs at the 
               specified level and those at higher priority levels
             enum:
               - ERROR
@@ -500,7 +491,7 @@ paths:
         For BTE, it is optional to have a callback property in the request-body. If
         the callback property is not included, BTE will handle the query in a polling
         manner: it will provide a job-id that can be used to check the status or retrieve
-        the Response using BTE's /v1/check_query_status/{id} endpoint.
+        the Response.
       parameters:
         - description: option to choose whether or not to enable caching
           in: query
@@ -546,11 +537,11 @@ paths:
             the Response will be sent to the callback url when complete. If the callback
             property is not included, BTE will handle the query in a polling manner: it
             will provide a job-id that can be used to check the status or retrieve
-            the Response using BTE's /v1/check_query_status/{id} endpoint.
+            the Response.
           content:
             application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/AsyncQueryResponse'
         '400':
           description: >-
             Bad request. The request is invalid according to this OpenAPI
@@ -596,7 +587,7 @@ paths:
       tags:
         - asyncquery
       summary: >-
-        This endpoint is for asynchronously querying an individual SmartAPI KP API (that has x-bte annotation)
+        This endpoint is for asynchronously querying an individual SmartAPI KP API (that has x-bte annotation) 
         as a TRAPI KP API.
 
         Initiate a query that will be handled in an asynchronous manner (there is a
@@ -604,7 +595,7 @@ paths:
         For BTE, it is optional to have a callback property in the request-body. If
         the callback property is not included, BTE will handle the query in a polling
         manner: it will provide a job-id that can be used to check the status or retrieve
-        the Response using BTE's /v1/check_query_status/{id} endpoint.
+        the Response.
       parameters:
         - description: >-
             SmartAPI ID of an API with x-bte annotation. The easiest way to find these is to read the list of APIs BTE uses
@@ -659,11 +650,11 @@ paths:
             the Response will be sent to the callback url when complete. If the callback
             property is not included, BTE will handle the query in a polling manner: it
             will provide a job-id that can be used to check the status or retrieve
-            the Response using BTE's /v1/check_query_status/{id} endpoint.
+            the Response.
           content:
             application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/AsyncQueryResponse'
         '400':
           description: >-
             Bad request. The request is invalid according to this OpenAPI
@@ -709,7 +700,7 @@ paths:
       tags:
         - asyncquery
       summary: >-
-        This endpoint is for asynchronously querying an individual Translator team's SMARTAPI KP APIs (that have x-bte annotation)
+        This endpoint is for asynchronously querying an individual Translator team's SMARTAPI KP APIs (that have x-bte annotation) 
         as an individual TRAPI service by specifying the team name.
 
         Initiate a query that will be handled in an asynchronous manner (there is a
@@ -717,14 +708,13 @@ paths:
         For BTE, it is optional to have a callback property in the request-body. If
         the callback property is not included, BTE will handle the query in a polling
         manner: it will provide a job-id that can be used to check the status or retrieve
-        the Response using BTE's /v1/check_query_status/{id} endpoint.
+        the Response.
       parameters:
         - description: >-
             Translator Team Name. Current options: Service Provider, Multiomics Provider, Text Mining Provider.
             The easiest way to find what KP APIs would be included under these teams is to read the list of APIs BTE uses
             https://github.com/biothings/biothings_explorer/blob/main/src/config/apis.js.
-            Note that Service Provider endpoints are also advertised separately as a KP
-            http://smart-api.info/registry?q=36f82f05705c317bac17ddae3a0ea2f0
+            Note that Service Provider endpoints are also registered separately as a KP in the SmartAPI Registry
           in: path
           name: team_name
           required: true
@@ -779,11 +769,11 @@ paths:
             the Response will be sent to the callback url when complete. If the callback
             property is not included, BTE will handle the query in a polling manner: it
             will provide a job-id that can be used to check the status or retrieve
-            the Response using BTE's /v1/check_query_status/{id} endpoint.
+            the Response.
           content:
             application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/AsyncQueryResponse'
         '400':
           description: >-
             Bad request. The request is invalid according to this OpenAPI
@@ -823,14 +813,53 @@ paths:
             application/json:
               schema:
                 type: string
+  ## custom: removed example so SmartAPI registry uptime check won't fail
+  /asyncquery_status/{job_id}:
+    get:
+      tags:
+        - asyncquery_status
+      summary: >-
+        Retrieve the current status of a previously submitted
+        asyncquery given its job_id
+      operationId: asyncquery_status
+      parameters:
+        - in: path
+          name: job_id
+          description: Identifier of the job for status request
+          # example: rXEOAosN3L
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: >-
+            Returns the status and current logs of a previously
+            submitted asyncquery.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AsyncQueryStatusResponse'
+        '404':
+          description: job_id not found
+        '501':
+          description: >-
+            Return code 501 indicates that this endpoint has not been
+            implemented at this site. Sites that implement /asyncquery
+            MUST implement /asyncquery_status/{job_id}, but those that
+            do not implement /asyncquery SHOULD NOT implement
+            /asyncquery_status.
+          content:
+            application/json:
+              schema:
+                type: string
 components:
   ## look for comments to see parts that have been modified for BTE
   ## also, many sections have additionalProperties: true
-  ## - Query: comment out workflow.allOf section since the $ref breaks execution of BTE's api-schema-builder/openapi-validator-middleware
+  ## - Query: comment out workflow.oneOf section since the $ref breaks execution of BTE's api-schema-builder/openapi-validator-middleware
   ## - AsyncQuery: callback property not required (commented it out of the 'required' field),
-  ##               comment out workflow.allOf section
-  ## - Response: comment out workflow.allOf section
-  ## - Attribute: comment out properties.attributes.items since the self-$ref breaks execution of
+  ##               comment out workflow.oneOf section
+  ## - Response: comment out workflow.oneOf section
+  ## - Attribute: comment out properties.attributes.items since the self-$ref breaks execution of 
   ##              BTE's api-schema-builder/openapi-validator-middleware
   schemas:
     Query:
@@ -855,13 +884,13 @@ components:
             require non-empty results and knowledge_graph fields.
         log_level:
           description: The least critical level of logs to return
-          allOf:
+          oneOf:
             - $ref: '#/components/schemas/LogLevel'
           nullable: true
         workflow:
           description: List of workflow steps to be executed.
-          # allOf:
-          #   - $ref: http://standards.ncats.io/workflow/1.3.2/schema
+          # oneOf:
+          #   - $ref: http://standards.ncats.io/workflow/1.3.4/schema
           nullable: true
         submitter:
           type: string
@@ -903,13 +932,13 @@ components:
             require non-empty results and knowledge_graph fields.
         log_level:
           description: The least critical level of logs to return
-          allOf:
+          oneOf:
             - $ref: '#/components/schemas/LogLevel'
           nullable: true
         workflow:
           description: List of workflow steps to be executed.
-          # allOf:
-          #   - $ref: http://standards.ncats.io/workflow/1.3.2/schema
+          # oneOf:
+          #   - $ref: http://standards.ncats.io/workflow/1.3.4/schema
           nullable: true
         submitter:
           type: string
@@ -924,6 +953,80 @@ components:
       ##   endpoint summary and 200 response description
         # - callback
         - message
+    AsyncQueryResponse:
+      type: object
+      description: >-
+        The AsyncQueryResponse object contains a payload that must be
+        returned from a submitted async_query.
+      properties:
+        status:
+          description: >-
+            One of a standardized set of short codes:
+            e.g. Accepted, QueryNotTraversable, KPsNotAvailable
+          type: string
+          example: Accepted
+          nullable: true
+        description:
+          description: >-
+            A brief human-readable description of the result of the
+            async_query submission.
+          type: string
+          example: Async_query has been queued
+          nullable: true
+        job_id:
+          description: >-
+            An identifier for the submitted job that can be used with
+            /async_query_status to receive an update on the status of
+            the job.
+          type: string
+          example: rXEOAosN3L
+          nullable: false
+      additionalProperties: true
+      required:
+        - job_id
+    AsyncQueryStatusResponse:
+      type: object
+      description: >-
+        The AsyncQueryStatusResponse object contains a payload that describes
+        the current status of a previously submitted async_query.
+      properties:
+        status:
+          description: >-
+            One of a standardized set of short codes:
+            Queued, Running, Completed, Failed
+          type: string
+          example: Running
+          nullable: false
+        description:
+          description: >-
+            A brief human-readable description of the current state
+            or summary of the problem if the status is Failed.
+          type: string
+          example: Callback URL returned 500
+          nullable: false
+        logs:
+          description: >-
+            A list of LogEntry items, containing errors, warnings, debugging
+            information, etc. List items MUST be in chronological order with
+            earliest first. The most recent entry should be last. Its timestamp
+            will be compared against the current time to see if there is
+            still activity.
+          type: array
+          items:
+            $ref: '#/components/schemas/LogEntry'
+          nullable: false
+        response_url:
+          description: >-
+            Optional URL that can be queried to restrieve the full TRAPI
+            Response.
+          type: string
+          example: https://arax.ncats.io/api/arax/v1.3/response/116481
+          nullable: true
+      additionalProperties: true
+      required:
+        - status
+        - description
+        - logs
     Response:
       type: object
       description: >-
@@ -953,16 +1056,26 @@ components:
           nullable: true
         logs:
           description: >-
-            Log entries containing errors, warnings, debugging information, etc
+            A list of LogEntry items, containing errors, warnings, debugging
+            information, etc. List items MUST be in chronological order with
+            earliest first.
           type: array
           items:
             $ref: '#/components/schemas/LogEntry'
           nullable: true
         workflow:
           description: List of workflow steps that were executed.
-          # allOf:
-          #   - $ref: http://standards.ncats.io/workflow/1.3.2/schema
+          # oneOf:
+          #   - $ref: http://standards.ncats.io/workflow/1.3.4/schema
           nullable: true
+        schema_version:
+          type: string
+          example: 1.4.0
+          description: Version label of the TRAPI schema used in this document
+        biolink_version:
+          type: string
+          example: 3.1.2
+          description: Version label of the Biolink model used in this document
       additionalProperties: true
       required:
         - message
@@ -991,16 +1104,24 @@ components:
           description: >-
             QueryGraph object that contains a serialization of a query in the
             form of a graph
-          allOf:
+          oneOf:
             - $ref: '#/components/schemas/QueryGraph'
           nullable: true
         knowledge_graph:
           description: >-
             KnowledgeGraph object that contains lists of nodes and edges
             in the thought graph corresponding to the message
-          allOf:
+          oneOf:
             - $ref: '#/components/schemas/KnowledgeGraph'
           nullable: true
+        auxiliary_graphs:
+          type: object
+          description: >-
+            Dictionary of AuxiliaryGraph instances that are used by Knowledge
+            Graph Edges and Result Analyses. These are referenced elsewhere by
+            the dictionary key.
+          additionalProperties:
+            $ref: '#components/schemas/AuxiliaryGraph'
       additionalProperties: false
     LogEntry:
       description: >-
@@ -1018,11 +1139,16 @@ components:
         timestamp:
           type: string
           format: date-time
-          description: Timestamp in ISO 8601 format
+          description: >-
+            Timestamp in ISO 8601 format, providing the LogEntry time
+            either in univeral coordinated time (UTC) using the 'Z' tag
+            (e.g 2020-09-03T18:13:49Z), or, if local time is provided,
+            the timezone offset must be provided
+            (e.g. 2020-09-03T18:13:49-04:00).
           example: '2020-09-03T18:13:49+00:00'
-          nullable: true
+          nullable: false
         level:
-          allOf:
+          oneOf:
             - $ref: '#/components/schemas/LogLevel'
           nullable: true
         code:
@@ -1036,6 +1162,9 @@ components:
           description: A human-readable log message
           nullable: true
       additionalProperties: true
+      required:
+        - timestamp
+        - message
     LogLevel:
       type: string
       description: Logging level
@@ -1066,32 +1195,17 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/NodeBinding'
-        edge_bindings:
-          type: object
+        analyses:
+          type: array
           description: >-
-            The dictionary of Input Query Graph to Result Knowledge Graph edge
-            bindings where the dictionary keys are the key identifiers of the
-            Query Graph edges and the associated values of those keys are
-            instances of EdgeBinding schema type (see below). This value is an
-            array of EdgeBindings since a given query edge may resolve to
-            multiple knowledge graph edges in the result.
-          additionalProperties:
-            type: array
-            items:
-              $ref: '#/components/schemas/EdgeBinding'
-        score:
-          type: number
-          format: float
-          example: 163.233
-          description: >-
-            A numerical score associated with this result indicating the
-            relevance or confidence of this result relative to others in the
-            returned set. Higher MUST be better.
-          nullable: true
+            The list of all Analysis components that contribute to the result.
+            See below for Analysis components.
+          items:
+            $ref: '#/components/schemas/Analysis'
       additionalProperties: true
       required:
         - node_bindings
-        - edge_bindings
+        - analyses
     NodeBinding:
       type: object
       description: >-
@@ -1099,14 +1213,15 @@ components:
           identified by the corresponding 'id' object key identifier of the
           Node within the Knowledge Graph. Instances of NodeBinding may
           include extra annotation in the form of additional properties.
-          (such annotation is not yet fully standardized).
+          (such annotation is not yet fully standardized). Each Node
+          Binding must bind directly to node in the original Query Graph.
       properties:
         id:
           $ref: '#/components/schemas/CURIE'
           description: >-
             The CURIE of a Node within the Knowledge Graph.
         query_id:
-          allOf:
+          oneOf:
             - $ref: '#/components/schemas/CURIE'
           description: >-
             An optional property to provide the CURIE in the QueryGraph to
@@ -1132,6 +1247,69 @@ components:
       additionalProperties: true
       required:
         - id
+    Analysis:
+      type: object
+      description: >-
+        An analysis is a dictionary that contains information about
+        the result tied to a particular service. Each Analysis is
+        generated by a single reasoning service, and describes the
+        outputs of analyses performed by the reasoner on a particular
+        Result (e.g. a result score), along with provenance information
+        supporting the analysis (e.g. method or data that supported
+        generation of the score).
+      properties:
+        resource_id:
+          $ref: '#/components/schemas/CURIE'
+          description: The id of the resource generating this Analysis
+        score:
+          type: number
+          format: float
+          example: 163.233
+          description: >-
+            A numerical score associated with this result indicating the
+            relevance or confidence of this result relative to others in the
+            returned set. Higher MUST be better.
+          nullable: true
+        edge_bindings:
+          type: object
+          description: >-
+            The dictionary of input Query Graph to Knowledge Graph edge
+            bindings where the dictionary keys are the key identifiers of the
+            Query Graph edges and the associated values of those keys are
+            instances of EdgeBinding schema type (see below). This value is an
+            array of EdgeBindings since a given query edge may resolve to
+            multiple Knowledge Graph Edges.
+          additionalProperties:
+            type: array
+            items:
+              $ref: '#/components/schemas/EdgeBinding'
+        support_graphs:
+          type: array
+          description: >-
+            This is a list of references to Auxiliary Graph instances
+            that supported the analysis of a Result as performed by the
+            reasoning service. Each item in the list is the key of a
+            single Auxiliary Graph.
+          nullable: true
+          items:
+            type: string
+        scoring_method:
+          type: string
+          description: >-
+            An identifier and link to an explanation for the method used
+            to generate the score
+          nullable: true
+        attributes:
+          type: array
+          description: >-
+            The attributes of this particular Analysis.
+          items:
+            $ref: '#/components/schemas/Attribute'
+          nullable: true
+      additionalProperties: true
+      required:
+        - resource_id
+        - edge_bindings
     EdgeBinding:
       type: object
       description: >-
@@ -1139,6 +1317,9 @@ components:
         identified by the corresponding 'id' object key identifier of the
         Edge within the Knowledge Graph. Instances of EdgeBinding may include
         extra annotation (such annotation is not yet fully standardized).
+        Edge bindings are captured within a specific reasoner's Analysis
+        object because the Edges in the Knowledge Graph that get bound to
+        the input Query Graph may differ between reasoners.
       properties:
         id:
           type: string
@@ -1156,6 +1337,36 @@ components:
       additionalProperties: true
       required:
         - id
+    AuxiliaryGraph:
+      type: object
+      description: >-
+        A single AuxiliaryGraph instance that is used by Knowledge Graph
+        Edges and Result Analyses. Edges comprising an Auxiliary Graph
+        are a subset of the Knowledge Graph in the message. Data creators
+        can create an AuxiliaryGraph to assemble a specific collections
+        of edges from the Knowledge Graph into a named graph that can be
+        referenced from an Edge as evidence/explanation supporting that Edge,
+        or from a Result Analysis as information used to generate a score.
+      properties:
+        edges:
+          type: array
+          description: >-
+            List of edges that form the Auxiliary Graph. Each item is a
+            reference to a single Knowledge Graph edge
+          items:
+            type: string
+          nullable: false
+          minItems: 1
+        attributes:
+          type: array
+          description: >-
+            Attributes of the Auxiliary Graph
+          items:
+            $ref: '#/components/schemas/Attribute'
+          nullable: true
+      additionalProperties: true
+      required:
+        - edges
     KnowledgeGraph:
       type: object
       description: >-
@@ -1228,6 +1439,10 @@ components:
           nullable: true
         categories:
           type: array
+          description: >-
+            These should be Biolink Model categories and are allowed
+            to be of type 'abstract' or 'mixin' (only in QGraphs!).
+            Use of 'deprecated' categories should be avoided.
           items:
             $ref: '#/components/schemas/BiolinkEntity'
           minItems: 1
@@ -1259,7 +1474,7 @@ components:
     QEdge:
       type: object
       description: >-
-        An edge in the QueryGraph used as an filter pattern specification in a
+        An edge in the QueryGraph used as a filter pattern specification in a
         query. If the optional predicate property is not specified,
         it is assumed to be a wildcard match to the target knowledge space.
         If specified, the ontological inheritance hierarchy associated with
@@ -1283,6 +1498,10 @@ components:
           type: string
         predicates:
           type: array
+          description: >-
+            These should be Biolink Model predicates and are allowed to be of
+            type 'abstract' or 'mixin' (only in QGraphs!). Use of 'deprecated'
+            predicates should be avoided.
           items:
             $ref: '#/components/schemas/BiolinkPredicate'
           minItems: 1
@@ -1341,6 +1560,10 @@ components:
           nullable: true
         categories:
           type: array
+          description: >-
+            These should be Biolink Model categories and are NOT allowed
+            to be of type 'abstract' or 'mixin'. Returning 'deprecated'
+            categories should also be avoided.
           items:
             $ref: '#/components/schemas/BiolinkEntity'
           nullable: true
@@ -1392,7 +1615,7 @@ components:
             Value of the attribute. May be any data type, including a list.
           example: 0.000153
         value_type_id:
-          allOf:
+          oneOf:
             - $ref: '#/components/schemas/CURIE'
           description: >-
             CURIE describing the semantic type of an  attribute's value. Use
@@ -1445,39 +1668,63 @@ components:
         resulting from a query upon the underlying knowledge source.
       properties:
         predicate:
-          allOf:
+          description: >-
+            The type of relationship between the subject and object
+            for the statement expressed in an Edge. These should be
+            Biolink Model predicate terms and are NOT allowed
+            to be of type 'abstract' or 'mixin'. Returning 'deprecated'
+            predicate terms should also be avoided.
+          example: biolink:gene_associated_with_condition
+          oneOf:
             - $ref: '#/components/schemas/BiolinkPredicate'
-          nullable: true
+          nullable: false
         subject:
-          $ref: '#/components/schemas/CURIE'
-          example: OMIM:603903
           description: >-
             Corresponds to the map key CURIE of the
             subject concept node of this relationship edge.
+          example: MONDO:0011382
+          oneOf:
+            - $ref: '#/components/schemas/CURIE'
+          nullable: false
         object:
-          $ref: '#/components/schemas/CURIE'
-          example: UniProtKB:P00738
           description: >-
             Corresponds to the map key CURIE of the
             object concept node of this relationship edge.
+          example: UniProtKB:P00738
+          oneOf:
+            - $ref: '#/components/schemas/CURIE'
+          nullable: false
         attributes:
-          type: array
           description: A list of additional attributes for this edge
           items:
             $ref: '#/components/schemas/Attribute'
           nullable: true
-        qualifiers:
           type: array
+        qualifiers:
           description: >-
             A set of Qualifiers that act together to add nuance
             or detail to the statement expressed in an Edge.
           items:
             $ref: '#/components/schemas/Qualifier'
           nullable: true
+          type: array
+        sources:
+          type: array
+          description: >-
+            A list of RetrievalSource objects that provide information
+            about how a particular Information Resource served
+            as a source from which the knowledge expressed in an Edge,
+            or data used to generate this knowledge, was retrieved.
+          items:
+            $ref: '#/components/schemas/RetrievalSource'
+          minItems: 1
+          nullable: false
       additionalProperties: false
       required:
-        - subject
         - object
+        - predicate
+        - subject
+        - sources
     Qualifier:
       additionalProperties: false
       description: >-
@@ -1485,12 +1732,20 @@ components:
       type: object
       properties:
         qualifier_type_id:
-          type: string
+          $ref: '#/components/schemas/CURIE'
           description: >-
-            The category of the qualifier, drawn from a hierarchy of qualifier
-            slots in the Biolink model (e.g. subject_aspect, subject_direction,
-            object_aspect, object_direction, etc).
-          example: subject_aspect
+            CURIE for a Biolink 'qualifier' association slot, generally taken
+            from Biolink association slots designated for this purpose
+            (that is, association slots with names ending in 'qualifier')
+            e.g. biolink:subject_aspect_qualifier, 
+            biolink:subject_direction_qualifier,
+            biolink:object_aspect_qualifier, etc. Such qualifiers are used
+            to elaborate a second layer of meaning of a knowledge graph edge.
+            Available qualifiers are edge properties in the Biolink Model (see
+            https://biolink.github.io/biolink-model/docs/edge_properties.html)
+            which have slot names with the suffix string 'qualifier'.
+          pattern: ^biolink:[a-z][a-z_]*$
+          example: biolink:subject_aspect_qualifier
           nullable: false
         qualifier_value:
           type: string
@@ -1498,7 +1753,10 @@ components:
             The value associated with the type of the qualifier, drawn from
             a set of controlled values by the type as specified in
             the Biolink model (e.g. 'expression' or 'abundance' for the
-            qualifier type 'subject_aspect', etc).
+            qualifier type 'biolink:subject_aspect_qualifier', etc).
+            The enumeration of qualifier values for a given qualifier
+            type is generally going to be constrained by the category
+            of edge (i.e. biolink:Association subtype) of the (Q)Edge.
           example: expression
           nullable: false
       required:
@@ -1511,9 +1769,9 @@ components:
         qualifier_types and qualifier_values of a set of
         Qualifiers attached to an edge. For example, it can constrain a
         "ChemicalX - affects - ?Gene" query to return only edges where
-        ChemicalX specifically affects the 'expression' of the Gene,
-        by constraining on the qualifier_type "object_aspect" with
-        a qualifier_value of "expression".
+        ChemicalX specifically affects the 'expression' of the Gene, by
+        constraining on the qualifier_type "biolink:object_aspect_qualifier"
+        with a qualifier_value of "expression".
       properties:
         qualifier_set:
           type: array
@@ -1649,11 +1907,49 @@ components:
           items:
             $ref: '#/components/schemas/MetaAttribute'
           nullable: true
+        qualifiers:
+          description: >-
+            Qualifiers that are possible to be found on this edge type.
+          items:
+            $ref: '#/components/schemas/MetaQualifier'
+          nullable: true
+          type: array
+        association:
+          description: >-
+            The Biolink association type (entity) that this edge represents.
+            Associations are classes in Biolink
+            that represent a relationship between two entities.
+            For example, the association 'gene interacts with gene'
+            is represented by the Biolink class,
+            'biolink:GeneToGeneAssociation'.  If association
+            is filled out, then the testing harness can
+            help validate that the qualifiers are being used
+            correctly.
+          example: 'biolink:ChemicalToGeneAssociation'
+          $ref: '#/components/schemas/BiolinkEntity'
       required:
         - subject
         - predicate
         - object
       additionalProperties: false
+    MetaQualifier:
+      type: object
+      properties:
+        qualifier_type_id:
+          $ref: '#/components/schemas/CURIE'
+          description: >-
+            The CURIE of the qualifier type.
+          example: biolink:subject_aspect_qualifier
+          nullable: false
+        applicable_values:
+          type: array
+          description: >-
+                The list of values that are possible for this qualifier.
+          items:
+            type: string
+            example: [expression, activity, abundance, degradation]
+      required:
+        - qualifier_type_id
     MetaAttribute:
       type: object
       properties:
@@ -1698,7 +1994,7 @@ components:
         Generic query constraint for a query node or query edge
       properties:
         id:
-          allOf:
+          oneOf:
             - $ref: '#/components/schemas/CURIE'
           description: >-
             CURIE of the concept being constrained. For properties
@@ -1784,3 +2080,70 @@ components:
         - operator
         - value
       additionalProperties: false
+    RetrievalSource:
+      type: object
+      description: >-
+        Provides information about how a particular InformationResource
+        served as a source from which knowledge expressed in an Edge, or
+        data used to generate this knowledge, was retrieved.
+      properties:
+        resource_id:
+          $ref: '#/components/schemas/CURIE'
+          description: >-
+            The CURIE for an Information Resource that served as a source
+            of knowledge expressed in an Edge, or a source of data used to
+            generate this knowledge.
+          example: infores:drugbank
+          nullable: false
+        resource_role:
+          $ref: '#/components/schemas/ResourceRoleEnum'
+          description: >-
+            The role played by the InformationResource in serving as a
+            source for an Edge. Note that a given Edge should have one
+            and only one 'primary' source, and may have any number of
+            'aggregator' or 'supporting data' sources.
+        upstream_resource_ids:
+          type: array
+          items:
+            $ref: '#/components/schemas/CURIE'
+          description: >-
+            An upstream InformationResource from which the resource
+            being described directly retrieved a record of the knowledge
+            expressed in the Edge, or data used to generate this knowledge.
+            This is an array because there are cases where a merged Edge
+            holds knowledge that was retrieved from multiple sources. e.g.
+            an Edge provided by the ARAGORN ARA can expressing knowledge it
+            retrieved from both the automat-mychem-info and molepro KPs,
+            which both provided it with records of this single fact.
+          example: [infores:automat-mychem-info, infores:molepro]
+        source_record_urls:
+          type: array
+          items: 
+            type: string
+          description: >-
+            A URL linking to a specific web page or document provided by the 
+            source, that contains a record of the knowledge expressed in the 
+            Edge. If the knowledge is contained in more than one web page on 
+            an Information Resource's site, urls MAY be provided for each. 
+            For example, Therapeutic Targets Database (TTD) has separate web 
+            pages for 'Imatinib' and its protein target KIT, both of which hold 
+            the claim that 'the KIT protein is a therapeutic target for Imatinib'.         
+          example: >-
+            [https://db.idrblab.net/ttd/data/drug/details/d0az3c, 
+            https://db.idrblab.net/ttd/data/target/details/t57700]
+      required:
+        - resource_id
+        - resource_role
+      additionalProperties: true
+    ResourceRoleEnum:
+      type: string
+      description: >-
+        The role played by the InformationResource in serving as a
+        source for an Edge. Note that a given Edge should have one
+        and only one 'primary' source, and may have any number of
+        'aggregator' or 'supporting data' sources.  This enumeration
+        is found in Biolink Model, but is repeated here for convenience.
+      enum:
+        - primary_knowledge_source
+        - aggregator_knowledge_source
+        - supporting_data_source

--- a/docs/smartapi.yaml
+++ b/docs/smartapi.yaml
@@ -418,68 +418,6 @@ paths:
             application/json:
               schema:
                 type: string
-  ## not TRAPI spec: BTE-specific endpoint related to asyncquery
-  /check_query_status/{id}:
-  ## moved because smartapi-editor gave alert that a non-existent post endpoint wouldn't know what {id} is
-    parameters:
-      - description: job-id
-        in: path
-        name: id
-        required: true
-        ## Cache refreshing means this will be changing pretty often, so not including an example
-        schema:
-          type: string
-    get:
-      tags:
-        - asyncquery_status
-      summary: >-
-        This endpoint can be used when a Query was sent to BTE through an /asyncquery
-        endpoint without a callback property: BTE then handled it in a polling manner and
-        provided a job id. The job id can be used here to check the status or retrieve
-        the Response.
-      parameters:
-        - description: option to override original query log level
-          in: query
-          name: log_level
-          required: false
-          schema:
-            type: string
-            description: >-
-              Logging level. The order of priority is ERROR, WARNING, INFO, DEBUG. BTE will return all logs at the 
-              specified level and those at higher priority levels
-            enum:
-              - ERROR
-              - WARNING
-              - INFO
-              - DEBUG
-      responses:
-        '200':
-          description: Returns status. If successfully completed, it will return a TRAPI Response object under the field returnvalue
-          content:
-            application/json:
-              schema:
-                type: object
-                required:
-                  - id
-                  - state
-                properties:
-                  id:
-                    description: the job-id
-                    type: string
-                  state:
-                    description: the status of the job
-                  reason:
-                    description: when the state is 'failed', this field states a reason for the failure
-                    type: string
-                  returnvalue:
-                    ## returnvalue.response is where the TRAPI Response is
-                    description: >-
-                      When the state is 'completed', this will contain the TRAPI Response object. Note
-                      that BTE might return an error, no results, etc as a Response...
-                    type: object
-                    properties:
-                      response:
-                        $ref: '#/components/schemas/Response'
   ## modified TRAPI spec: summary sections tell users that AsyncQuery schema was changed to make callback optional
   /asyncquery:
     post:

--- a/src/config/apis.js
+++ b/src/config/apis.js
@@ -156,86 +156,86 @@ exports.API_LIST = {
         // TRAPI (Translator standard) APIs: Automat
         // not accessible by team or api-specific endpoints
         // Notes: We don't ingest the following:
-        // - Automat-covidkop: seems to repeat a lot of data that is in the other APIs
-        // - Automat-mole-pro-fda: doesn't have edges / associations
-        // - Automat-mychem-info: since we ingest MyChem directly through x-bte annotations
         // - Automat-robokop: seems to repeat a lot of data that is in the other APIs
         {
         // this API overlaps with our Biolink API registration, but we have bugs with our api-response-transform
         //   this may have been updated more recently / transformed data into TRAPI format
-            id: '25085b05fd1afcebb497724d147cfb44',
-            name: 'Automat-biolink(Trapi v1.3.0)'
+            id: 'ef0656900ff73f861611bcad87a94bce',
+            name: 'Automat-biolink(Trapi v1.4.0)'
         },
         {
             // this may overlap with info we have in MyDisease, MyChem, and other APIs...
-            id: '89aa98098ba4329aa49b43ff8d21ffbb',
-            name: 'Automat-ctd(Trapi v1.3.0)'
+            id: '97da45e75266b021fae885735befad07',
+            name: 'Automat-ctd(Trapi v1.4.0)'
+        },
+        // 2023-05-10: missing from registry
+        // {
+        //     id: '463525b319d7e1ef8f705bce953d01bd',
+        //     name: 'Automat-cord19(Trapi v1.3.0)'
+        // },
+        {
+            id: 'a80b9c70e756453d1ce8971b59fe1778',
+            name: 'Automat-drug-central(Trapi v1.4.0)'
         },
         {
-            id: '463525b319d7e1ef8f705bce953d01bd',
-            name: 'Automat-cord19(Trapi v1.3.0)'
+            id: '2575e053d0a631433b447995e1bc9602',
+            name: 'Automat-gtex(Trapi v1.4.0)'
         },
         {
-            id: '539873b1f2f2eb913efaee411e09eaa7',
-            name: 'Automat-drug-central(Trapi v1.3.0)'
+            id: '387f7a2c21656ddfcce5ccf9ea459049',
+            name: 'Automat-gtopdb(Trapi v1.4.0)'
         },
         {
-            id: '272c2357763e4faf737f1cba94beaa1d',
-            name: 'Automat-gtex(Trapi v1.3.0)'
+            id: 'cd9fc0ca8cc6d9f56bd56a34766de791',
+            name: 'Automat-gwas-catalog(Trapi v1.4.0)'
         },
         {
-            id: 'fb1f3780ad67b030cb0617363afa8f61',
-            name: 'Automat-gwas-catalog(Trapi v1.3.0)'
+            id: '8a1e2c2eade9fe3a932ba1dbb7f85688',
+            name: 'Automat-hetio(Trapi v1.4.0)'
         },
         {
-            id: 'aacdd9e863bb659574d302f084084976',
-            name: 'Automat-gtopdb(Trapi v1.3.0)'
+            id: '067d3a847117c6f42896cc8cd140a704',
+            name: 'Automat-hgnc(Trapi v1.4.0)'
         },
         {
-            id: '7382f0fabffce3cc7f7b8b6358c69259',
-            name: 'Automat-hgnc(Trapi v1.3.0)'
-        },
-        {
-            id: 'ee2d2eae42ca30fe82946d3f42febaa0',
-            name: 'Automat-hmdb(Trapi v1.3.0)'
-        },
-        {
-            id: '830600da121a5accc955cbf62e60f802',
-            name: 'Automat-hetio(Trapi v1.3.0)'
+            id: '0658e8749b9601a5faba5157ba12eb06',
+            name: 'Automat-hmdb(Trapi v1.4.0)'
         },
         {
         // this API overlaps with our BioThings GO APIs, but
         //   may have been updated more recently / transformed data into TRAPI format
-            id: 'f30339a6894a146a19a34974712ca2e3',
-            name: 'Automat-human-goa(Trapi v1.3.0)'
+            id: '43cf256c660cc5bdeac23fdd3063d474',
+            name: 'Automat-human-goa(Trapi v1.4.0)'
         },
         {
-            id: '44e7a1147ca8657f50af6bb25982762d',
-            name: 'Automat-icees-kg(Trapi v1.3.0)'
+            id: '76a164ff43e7ab39a5b98a782f6361bf',
+            name: 'Automat-icees-kg(Trapi v1.4.0)'
         },
         {
-            id: 'e0687431a9ff88344d20e83e0c99ee7d',
-            name: 'Automat-intact(Trapi v1.3.0)'
+            id: '0b0a4d48ccd9ad2fd34ee53c34f87e94',
+            name: 'Automat-intact(Trapi v1.4.0)'
+        },
+        // 2023-05-10: no TRAPI 1.4 version from registry
+        // {
+        //     id: '4c6f9117581531161849e60ea906f0be',
+        //     name: 'Automat-ontology-hierarchy(Trapi v1.3.0)'
+        // },
+        {
+            id: '26ca4939d437c411bcb65b85a9dc2b99',
+            name: 'Automat-panther(Trapi v1.4.0)'
         },
         {
-            id: '4c6f9117581531161849e60ea906f0be',
-            name: 'Automat-ontology-hierarchy(Trapi v1.3.0)'
+            id: '1c71f68839a44b1b857e79ae7f7e3381',
+            name: 'Automat-pharos(Trapi v1.4.0)'
         },
+        // 2023-05-10: no TRAPI 1.4 version from registry
+        // {
+        //     id: 'ef9027a7d2246c6540cc7b3ce202d89f',
+        //     name: 'Automat-uberongraph(Trapi v1.3.0)'
+        // },
         {
-            id: '2a879882329b000c7e7f08c2d71ccffd',
-            name: 'Automat-panther(Trapi v1.3.0)'
-        },
-        {
-            id: '0295640b4d060133e4296dda4c31da47',
-            name: 'Automat-pharos(Trapi v1.3.0)'
-        },
-        {
-            id: 'ef9027a7d2246c6540cc7b3ce202d89f',
-            name: 'Automat-uberongraph(Trapi v1.3.0)'
-        },
-        {
-            id: '79310edd01cae96f3d8495250e625886',
-            name: 'Automat-viral-proteome(Trapi v1.3.0)'
+            id: '465ff6de7ddf35ca8b2df6c0b01e6554',
+            name: 'Automat-viral-proteome(Trapi v1.4.0)'
         },
         // TRAPI (Translator standard) APIs: COHD
         // not accessible by team or api-specific endpoints
@@ -245,8 +245,8 @@ exports.API_LIST = {
         // - COHD for COVID-19 should work but BTE gets a 500 when retrieving meta_knowledge_graph...
         //   smartapi ID fc8245e92c970298449294fc04211869
         {
-            id: '51c178099fa2dc99b5d8fff8bf9f1a0d',
-            name: 'COHD TRAPI 1.3'
+            id: 'e892e3cea582cd28f4e368e463876d21',
+            name: 'COHD TRAPI'
         },
         // TRAPI (Translator standard) APIs: CHP
         // not accessible by team or api-specific endpoints

--- a/src/config/apis.js
+++ b/src/config/apis.js
@@ -248,33 +248,14 @@ exports.API_LIST = {
             id: 'e892e3cea582cd28f4e368e463876d21',
             name: 'COHD TRAPI'
         },
-        // TRAPI (Translator standard) APIs: CHP
+        // TRAPI (Translator standard) APIs: CHP. Temporarily commenting out because the registration is TRAPI 1.3
         // not accessible by team or api-specific endpoints
-        {
-            id: '855adaa128ce5aa58a091d99e520d396',
-            name: 'Connections Hypothesis Provider API'
-        },
-        // TRAPI (Translator standard) APIs: ICEES
-        // not accessible by team or api-specific endpoints
-        // currently commented out because of issues
         // {
-        //     id: '749c8f527fa07964de692e0969b71a4e',
-        //     name: 'ICEES DILI Instance API - production'
-        // },
-        // {
-        //     id: 'bb806f5c81e86fe12660fa307d4b0a97',
-        //     name: 'ICEES Asthma Instance API - production'
-        // },
-        // {
-        //     id: '4153c947a32e2e2a55a320d0bee22077',
-        //     name: 'ICEES PCD Instance API - production'
+        //     id: '855adaa128ce5aa58a091d99e520d396',
+        //     name: 'Connections Hypothesis Provider API'
         // },
     ],
     exclude: [ // explicitly disabled for use even in by_api endpoint. for TRAPI and APIs annotated with SmartAPI x-bte
-        // Temporary exclusion due to incompatible x-bte annotation
-        {
-            id: 'e9f69b81e755e163fdf6c41a2b5e07c0',
-            name: 'OpenPredict API',
-        },
+
     ]
 };

--- a/src/config/apis.js
+++ b/src/config/apis.js
@@ -248,12 +248,12 @@ exports.API_LIST = {
             id: 'e892e3cea582cd28f4e368e463876d21',
             name: 'COHD TRAPI'
         },
-        // TRAPI (Translator standard) APIs: CHP. Temporarily commenting out because the registration is TRAPI 1.3
+        // TRAPI (Translator standard) APIs: CHP
         // not accessible by team or api-specific endpoints
-        // {
-        //     id: '855adaa128ce5aa58a091d99e520d396',
-        //     name: 'Connections Hypothesis Provider API'
-        // },
+        {
+            id: '855adaa128ce5aa58a091d99e520d396',
+            name: 'Connections Hypothesis Provider API'
+        },
     ],
     exclude: [ // explicitly disabled for use even in by_api endpoint. for TRAPI and APIs annotated with SmartAPI x-bte
 

--- a/src/config/apis.js
+++ b/src/config/apis.js
@@ -168,11 +168,6 @@ exports.API_LIST = {
             id: '97da45e75266b021fae885735befad07',
             name: 'Automat-ctd(Trapi v1.4.0)'
         },
-        // 2023-05-10: missing from registry
-        // {
-        //     id: '463525b319d7e1ef8f705bce953d01bd',
-        //     name: 'Automat-cord19(Trapi v1.3.0)'
-        // },
         {
             id: 'a80b9c70e756453d1ce8971b59fe1778',
             name: 'Automat-drug-central(Trapi v1.4.0)'
@@ -215,11 +210,6 @@ exports.API_LIST = {
             id: '0b0a4d48ccd9ad2fd34ee53c34f87e94',
             name: 'Automat-intact(Trapi v1.4.0)'
         },
-        // 2023-05-10: no TRAPI 1.4 version from registry
-        // {
-        //     id: '4c6f9117581531161849e60ea906f0be',
-        //     name: 'Automat-ontology-hierarchy(Trapi v1.3.0)'
-        // },
         {
             id: '26ca4939d437c411bcb65b85a9dc2b99',
             name: 'Automat-panther(Trapi v1.4.0)'
@@ -228,11 +218,6 @@ exports.API_LIST = {
             id: '1c71f68839a44b1b857e79ae7f7e3381',
             name: 'Automat-pharos(Trapi v1.4.0)'
         },
-        // 2023-05-10: no TRAPI 1.4 version from registry
-        // {
-        //     id: 'ef9027a7d2246c6540cc7b3ce202d89f',
-        //     name: 'Automat-uberongraph(Trapi v1.3.0)'
-        // },
         {
             id: '465ff6de7ddf35ca8b2df6c0b01e6554',
             name: 'Automat-viral-proteome(Trapi v1.4.0)'

--- a/src/config/apis.js
+++ b/src/config/apis.js
@@ -240,7 +240,7 @@ exports.API_LIST = {
         // TRAPI (Translator standard) APIs: CHP
         // not accessible by team or api-specific endpoints
         {
-            id: '855adaa128ce5aa58a091d99e520d396',
+            id: '23f770568b92b7a82063989b3ddd9706',
             name: 'Connections Hypothesis Provider API'
         },
     ],

--- a/src/config/apis.js
+++ b/src/config/apis.js
@@ -234,7 +234,7 @@ exports.API_LIST = {
         // - COHD for COVID-19 should work but BTE gets a 500 when retrieving meta_knowledge_graph...
         //   smartapi ID fc8245e92c970298449294fc04211869
         {
-            id: 'e892e3cea582cd28f4e368e463876d21',
+            id: 'af364143267ad5235bf78c1511223875',
             name: 'COHD TRAPI'
         },
         // TRAPI (Translator standard) APIs: CHP

--- a/src/config/smartapi_exclusions.js
+++ b/src/config/smartapi_exclusions.js
@@ -8,4 +8,13 @@ exports.EXCLUDE_LIST = [
         id: '36f82f05705c317bac17ddae3a0ea2f0',
         name: 'Service Provider TRAPI'
     },
+    // temp trapi 1.4 instances
+    {
+        id: '96ee53e4cbc29630dae29762083ba05d',
+        name: 'BioThings Explorer (BTE) TRAPI'
+    },
+    {
+        id: '71d5b21590384069eb4534b50a6b71f7',
+        name: 'Service Provider TRAPI'
+    },
 ]

--- a/src/config/smartapi_overrides.json
+++ b/src/config/smartapi_overrides.json
@@ -3,5 +3,7 @@
     "only_overrides": false
   },
   "apis": {
+    "978fe380a147a8641caf72320862697b": "https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/text-mining-provider-trapi-1.4/text_mining/smartapi.yaml",
+    "08a5ddcde71b4bf838327ef469076acd": "https://raw.githubusercontent.com/GitHubbit/translator-api-registry/master/multiomics_clinical_trials/smartapi.yaml"
   }
 }

--- a/src/controllers/cron/update_local_smartapi.js
+++ b/src/controllers/cron/update_local_smartapi.js
@@ -106,9 +106,7 @@ const getTRAPIWithPredicatesEndpoint = specs => {
         if ("/meta_knowledge_graph" in spec.paths) {
           if (
             (Object.prototype.hasOwnProperty.call(spec.info["x-trapi"], "version") &&
-              spec.info["x-trapi"].version.includes("1.2")) ||
-            (Object.prototype.hasOwnProperty.call(spec.info["x-trapi"], "version") &&
-              spec.info["x-trapi"].version.includes("1.3"))
+              spec.info["x-trapi"].version.includes("1.4"))
           ) {
             api["predicates_path"] = "/meta_knowledge_graph";
             trapi.push(api);


### PR DESCRIPTION
A PR may be an easier way to track where this code has been deployed. 

This branch currently includes:
* overrides to get BTE hooked up to TRAPI 1.4 sources data for Text-Mining/Multiomics KPs
* API_LIST changes to get BTE hooked up to TRAPI 1.4 KPs
* other additions / cleanups to API_LIST that are also in the main branch