### PR TITLE
feat: add biothings ttd to api config

### DIFF
--- a/src/config/apis.js
+++ b/src/config/apis.js
@@ -107,6 +107,10 @@ exports.API_LIST = {
             name: 'BioThings SEMMEDDB API'
         },
         {
+            id: 'e481efd21f8e8c1deac05662439c2294',
+            name: 'Biothings Therapeutic Target Database API'
+        },
+        {
             id: 'ec6d76016ef40f284359d17fbf78df20',
             name: 'BioThings UBERON API'
         },


### PR DESCRIPTION
@tokebe 

This has the same status as [suppKG](https://github.com/biothings/biothings_explorer/pull/724#issuecomment-1770085558): 

> There's one more issue to resolve, then this is ready to deploy:
> * whether the UI is using a "version" of the infores registry w/ suppKG info (see my Translator Slack [post](https://ncatstranslator.slack.com/archives/C03LX327RK8/p1697693837755999) asking about this) - this is so the UI can display provenance information properly for edges from this KP

But I'm not sure if a merge conflict will arise when trying to deploy both this and the suppKG PR. We want to keep both new config entries in the merge...

(Addresses https://github.com/biothings/pending.api/issues/123)
