### PR TITLE
Support pfocrUrl on enrichment objects

### DIFF
--- a/packages/types/src/trapi.ts
+++ b/packages/types/src/trapi.ts
@@ -121,6 +121,7 @@ export interface TrapiAuxiliaryGraph {
 
 export interface TrapiPfocrFigure {
   figureUrl: string;
+  pfocrUrl: string;
   pmc: string;
   matchedCuries: string[];
   score: number;


### PR DESCRIPTION
_Required by https://github.com/biothings/bte_trapi_query_graph_handler/pull/201 to address https://github.com/biothings/biothings_explorer/issues/837_