### PR TITLE
fix(tests): add pfocrUrl to TrapiPfocrFigure type

### DIFF
--- a/packages/types/src/trapi.ts
+++ b/packages/types/src/trapi.ts
@@ -121,6 +121,7 @@ export interface TrapiAuxiliaryGraph {
 
 export interface TrapiPfocrFigure {
   figureUrl: string;
+  pfocrUrl: string;
   pmc: string;
   matchedCuries: string[];
   score: number;


### PR DESCRIPTION
partially closes #846 \
Please refer to other packages for all PRs related to that issue.

- [x] added pfocrUrl to TrapiPfocrFigure type in `packages/types/trapi.ts`